### PR TITLE
Enhancement (ci): Add release-drafter action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+name-template: 'v$NEXT_PATCH_VERSION 🌈'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🖊️ Refactors'
+    labels:
+      - 'refactor'
+  - title: '👗 Style'
+    labels:
+      - 'style'
+  - title: '📝 Documentation'
+    labels:
+      - 'docs'
+      - 'documentation'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+sort-by: title
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -468,3 +468,11 @@ jobs:
     - name: Clean-up
       run: docker logout
       if: always()
+  update-draft-release:
+    needs: [build-v2-4-8-alpine-3-11, build-v2-4-7-alpine-3-10, build-v2-4-6-alpine-3-9, build-v2-4-6-alpine-3-8, build-v2-4-4-alpine-3-7, build-v2-4-4-alpine-3-6, build-v2-3-18-alpine-3-5, build-v2-3-18-alpine-3-4, build-v2-3-18-alpine-3-3]    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: toolmantim/release-drafter@v5.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -469,7 +469,8 @@ jobs:
       run: docker logout
       if: always()
   update-draft-release:
-    needs: [build-v2-4-8-alpine-3-11, build-v2-4-7-alpine-3-10, build-v2-4-6-alpine-3-9, build-v2-4-6-alpine-3-8, build-v2-4-4-alpine-3-7, build-v2-4-4-alpine-3-6, build-v2-3-18-alpine-3-5, build-v2-3-18-alpine-3-4, build-v2-3-18-alpine-3-3]    if: github.ref == 'refs/heads/master'
+    needs: [build-v2-4-8-alpine-3-11, build-v2-4-7-alpine-3-10, build-v2-4-6-alpine-3-9, build-v2-4-6-alpine-3-8, build-v2-4-4-alpine-3-7, build-v2-4-4-alpine-3-6, build-v2-3-18-alpine-3-5, build-v2-3-18-alpine-3-4, build-v2-3-18-alpine-3-3]
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -486,7 +486,8 @@ jobs:
       run: docker logout
       if: always()
   update-draft-release:
-    needs: [build-v2-4-8-alpine-3-11, build-v2-4-7-alpine-3-10, build-v2-4-6-alpine-3-9, build-v2-4-6-alpine-3-8, build-v2-4-4-alpine-3-7, build-v2-4-4-alpine-3-6, build-v2-3-18-alpine-3-5, build-v2-3-18-alpine-3-4, build-v2-3-18-alpine-3-3]    if: github.ref == 'refs/heads/master'
+    needs: [build-v2-4-8-alpine-3-11, build-v2-4-7-alpine-3-10, build-v2-4-6-alpine-3-9, build-v2-4-6-alpine-3-8, build-v2-4-4-alpine-3-7, build-v2-4-4-alpine-3-6, build-v2-3-18-alpine-3-5, build-v2-3-18-alpine-3-4, build-v2-3-18-alpine-3-3]
+    if: github.ref == 'refs/heads/release'
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -485,3 +485,11 @@ jobs:
     - name: Clean-up
       run: docker logout
       if: always()
+  update-draft-release:
+    needs: [build-v2-4-8-alpine-3-11, build-v2-4-7-alpine-3-10, build-v2-4-6-alpine-3-9, build-v2-4-6-alpine-3-8, build-v2-4-4-alpine-3-7, build-v2-4-4-alpine-3-6, build-v2-3-18-alpine-3-5, build-v2-3-18-alpine-3-4, build-v2-3-18-alpine-3-3]    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: toolmantim/release-drafter@v5.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/generate/templates/.github/workflows/ci-master-pr.yml.ps1
+++ b/generate/templates/.github/workflows/ci-master-pr.yml.ps1
@@ -71,3 +71,19 @@ $( $VARIANTS | % {
       if: always()
 '@
 })
+
+
+@"
+
+  update-draft-release:
+    needs: [$( ($VARIANTS | % { "build-$( $_['tag'].Replace('.', '-') )" }) -join ', ' )]
+"@
+@'
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: toolmantim/release-drafter@v5.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+'@

--- a/generate/templates/.github/workflows/ci-master-pr.yml.ps1
+++ b/generate/templates/.github/workflows/ci-master-pr.yml.ps1
@@ -79,6 +79,7 @@ $( $VARIANTS | % {
     needs: [$( ($VARIANTS | % { "build-$( $_['tag'].Replace('.', '-') )" }) -join ', ' )]
 "@
 @'
+
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:

--- a/generate/templates/.github/workflows/ci-release.yml.ps1
+++ b/generate/templates/.github/workflows/ci-release.yml.ps1
@@ -95,7 +95,8 @@ if ( $_['tag_as_latest'] ) {
     needs: [$( ($VARIANTS | % { "build-$( $_['tag'].Replace('.', '-') )" }) -join ', ' )]
 "@
 @'
-    if: github.ref == 'refs/heads/master'
+
+    if: github.ref == 'refs/heads/release'
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"

--- a/generate/templates/.github/workflows/ci-release.yml.ps1
+++ b/generate/templates/.github/workflows/ci-release.yml.ps1
@@ -88,3 +88,18 @@ if ( $_['tag_as_latest'] ) {
       if: always()
 '@
 })
+
+@"
+
+  update-draft-release:
+    needs: [$( ($VARIANTS | % { "build-$( $_['tag'].Replace('.', '-') )" }) -join ', ' )]
+"@
+@'
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: toolmantim/release-drafter@v5.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+'@


### PR DESCRIPTION
Requires a release-drafter on:

- `master`

Requires build on:

- `master`
- `pr`

Requires a release on 

- `release`
- not `tags`

Publish release notes on

- `tags` in format  `yyyy-MM-dd`. Cannot use semver since this is repo is a matrix build of various semvers.
- Release notes should only be published based on the last draft release notes on `master` before `master` was merged into `release`.
