### PR TITLE
Enhancement: Build multi arch docker image

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -94,7 +94,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -109,7 +109,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -124,7 +124,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -225,7 +225,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -240,7 +240,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -255,7 +255,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -355,7 +355,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -370,7 +370,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -385,7 +385,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -485,7 +485,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -500,7 +500,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -515,7 +515,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -615,7 +615,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -630,7 +630,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -645,7 +645,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -745,7 +745,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -760,7 +760,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -775,7 +775,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -875,7 +875,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -890,7 +890,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -905,7 +905,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -1005,7 +1005,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1020,7 +1020,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1035,7 +1035,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}

--- a/generate/templates/.github/workflows/ci-master-pr.yml.ps1
+++ b/generate/templates/.github/workflows/ci-master-pr.yml.ps1
@@ -13,7 +13,7 @@ jobs:
 '@
 
 $local:WORKFLOW_JOB_NAMES = $VARIANTS | % { "build-$( $_['tag'].Replace('.', '-') )" }
-$( $VARIANTS | % {
+$VARIANTS | % {
 @"
 
 
@@ -97,18 +97,21 @@ $( $VARIANTS | % {
         DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
         DOCKERHUB_REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
 
+
+'@
+@"
     - name: Build (PRs)
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        context: `${{ steps.prep.outputs.CONTEXT }}
+        platforms: $( if ($_['_metadata']['distro'] -eq 'alpine' -and $_['_metadata']['distro_version'] -in @( '3.3', '3.4', '3.5' ) ) { 'linux/amd64' } else { 'linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x' } )
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          `${{ github.repository }}:`${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
+          `${{ github.repository }}:`${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -118,12 +121,12 @@ $( $VARIANTS | % {
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v2
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        context: `${{ steps.prep.outputs.CONTEXT }}
+        platforms: $( if ($_['_metadata']['distro'] -eq 'alpine' -and $_['_metadata']['distro_version'] -in @( '3.3', '3.4', '3.5' ) ) { 'linux/amd64' } else { 'linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x' } )
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          `${{ github.repository }}:`${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
+          `${{ github.repository }}:`${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
@@ -133,15 +136,15 @@ $( $VARIANTS | % {
       if: github.ref == 'refs/heads/release'
       uses: docker/build-push-action@v2
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        context: `${{ steps.prep.outputs.CONTEXT }}
+        platforms: $( if ($_['_metadata']['distro'] -eq 'alpine' -and $_['_metadata']['distro_version'] -in @( '3.3', '3.4', '3.5' ) ) { 'linux/amd64' } else { 'linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x' } )
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          `${{ github.repository }}:`${{ steps.prep.outputs.VARIANT_TAG }}
+          `${{ github.repository }}:`${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
+          `${{ github.repository }}:`${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
 
-'@
+"@
 
 if ( $_['tag_as_latest'] ) {
 @'
@@ -160,7 +163,7 @@ if ( $_['tag_as_latest'] ) {
       run: docker logout
       if: always()
 '@
-})
+}
 
 @"
 


### PR DESCRIPTION
Note: There's only `linux/amd64` image for`alpine:3.3` to `alpine:3.5`, see https://hub.docker.com/_/alpine?tab=tags&page=1&ordering=last_updated&name=3.5