### PR TITLE
Refactor (config): Remove unused environment variables `OPENVPN_CLIENT_CONFIG_DIR`, `OPENVPN_STATUS_FILE`, `OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS`

### DIFF
--- a/generate/templates/docker-entrypoint.sh.ps1
+++ b/generate/templates/docker-entrypoint.sh.ps1
@@ -14,9 +14,6 @@ error() {
 # Env vars
 OPENVPN=openvpn
 OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
-# OPENVPN_CLIENT_CONFIG_DIR=${OPENVPN_CLIENT_CONFIG_DIR:-/etc/openvpn/ccd}
-# OPENVPN_STATUS_FILE=${OPENVPN_STATUS_FILE:-}
-# OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS={$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS:-10}
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
@@ -61,10 +58,6 @@ iptables -L -nv -t nat
 output "Generating command line"
 set "$OPENVPN" --cd /etc/openvpn
 set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
-# set "$@" --client-config-dir "$OPENVPN_CLIENT_CONFIG_DIR"
-if [ -n "$OPENVPN_STATUS_FILE" ]; then
-    set "$@" --status "$OPENVPN_STATUS_FILE" "$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS"
-fi
 
 # Exec
 ARGS="$@"

--- a/variants/v2.3.18-alpine-3.3/docker-entrypoint.sh
+++ b/variants/v2.3.18-alpine-3.3/docker-entrypoint.sh
@@ -13,9 +13,6 @@ error() {
 # Env vars
 OPENVPN=openvpn
 OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
-# OPENVPN_CLIENT_CONFIG_DIR=${OPENVPN_CLIENT_CONFIG_DIR:-/etc/openvpn/ccd}
-# OPENVPN_STATUS_FILE=${OPENVPN_STATUS_FILE:-}
-# OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS={$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS:-10}
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
@@ -60,10 +57,6 @@ iptables -L -nv -t nat
 output "Generating command line"
 set "$OPENVPN" --cd /etc/openvpn
 set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
-# set "$@" --client-config-dir "$OPENVPN_CLIENT_CONFIG_DIR"
-if [ -n "$OPENVPN_STATUS_FILE" ]; then
-    set "$@" --status "$OPENVPN_STATUS_FILE" "$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS"
-fi
 
 # Exec
 ARGS="$@"

--- a/variants/v2.3.18-alpine-3.4/docker-entrypoint.sh
+++ b/variants/v2.3.18-alpine-3.4/docker-entrypoint.sh
@@ -13,9 +13,6 @@ error() {
 # Env vars
 OPENVPN=openvpn
 OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
-# OPENVPN_CLIENT_CONFIG_DIR=${OPENVPN_CLIENT_CONFIG_DIR:-/etc/openvpn/ccd}
-# OPENVPN_STATUS_FILE=${OPENVPN_STATUS_FILE:-}
-# OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS={$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS:-10}
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
@@ -60,10 +57,6 @@ iptables -L -nv -t nat
 output "Generating command line"
 set "$OPENVPN" --cd /etc/openvpn
 set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
-# set "$@" --client-config-dir "$OPENVPN_CLIENT_CONFIG_DIR"
-if [ -n "$OPENVPN_STATUS_FILE" ]; then
-    set "$@" --status "$OPENVPN_STATUS_FILE" "$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS"
-fi
 
 # Exec
 ARGS="$@"

--- a/variants/v2.3.18-alpine-3.5/docker-entrypoint.sh
+++ b/variants/v2.3.18-alpine-3.5/docker-entrypoint.sh
@@ -13,9 +13,6 @@ error() {
 # Env vars
 OPENVPN=openvpn
 OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
-# OPENVPN_CLIENT_CONFIG_DIR=${OPENVPN_CLIENT_CONFIG_DIR:-/etc/openvpn/ccd}
-# OPENVPN_STATUS_FILE=${OPENVPN_STATUS_FILE:-}
-# OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS={$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS:-10}
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
@@ -60,10 +57,6 @@ iptables -L -nv -t nat
 output "Generating command line"
 set "$OPENVPN" --cd /etc/openvpn
 set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
-# set "$@" --client-config-dir "$OPENVPN_CLIENT_CONFIG_DIR"
-if [ -n "$OPENVPN_STATUS_FILE" ]; then
-    set "$@" --status "$OPENVPN_STATUS_FILE" "$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS"
-fi
 
 # Exec
 ARGS="$@"

--- a/variants/v2.4.11-alpine-3.10/docker-entrypoint.sh
+++ b/variants/v2.4.11-alpine-3.10/docker-entrypoint.sh
@@ -13,9 +13,6 @@ error() {
 # Env vars
 OPENVPN=openvpn
 OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
-# OPENVPN_CLIENT_CONFIG_DIR=${OPENVPN_CLIENT_CONFIG_DIR:-/etc/openvpn/ccd}
-# OPENVPN_STATUS_FILE=${OPENVPN_STATUS_FILE:-}
-# OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS={$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS:-10}
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
@@ -60,10 +57,6 @@ iptables -L -nv -t nat
 output "Generating command line"
 set "$OPENVPN" --cd /etc/openvpn
 set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
-# set "$@" --client-config-dir "$OPENVPN_CLIENT_CONFIG_DIR"
-if [ -n "$OPENVPN_STATUS_FILE" ]; then
-    set "$@" --status "$OPENVPN_STATUS_FILE" "$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS"
-fi
 
 # Exec
 ARGS="$@"

--- a/variants/v2.4.11-alpine-3.11/docker-entrypoint.sh
+++ b/variants/v2.4.11-alpine-3.11/docker-entrypoint.sh
@@ -13,9 +13,6 @@ error() {
 # Env vars
 OPENVPN=openvpn
 OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
-# OPENVPN_CLIENT_CONFIG_DIR=${OPENVPN_CLIENT_CONFIG_DIR:-/etc/openvpn/ccd}
-# OPENVPN_STATUS_FILE=${OPENVPN_STATUS_FILE:-}
-# OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS={$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS:-10}
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
@@ -60,10 +57,6 @@ iptables -L -nv -t nat
 output "Generating command line"
 set "$OPENVPN" --cd /etc/openvpn
 set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
-# set "$@" --client-config-dir "$OPENVPN_CLIENT_CONFIG_DIR"
-if [ -n "$OPENVPN_STATUS_FILE" ]; then
-    set "$@" --status "$OPENVPN_STATUS_FILE" "$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS"
-fi
 
 # Exec
 ARGS="$@"

--- a/variants/v2.4.12-alpine-3.12/docker-entrypoint.sh
+++ b/variants/v2.4.12-alpine-3.12/docker-entrypoint.sh
@@ -13,9 +13,6 @@ error() {
 # Env vars
 OPENVPN=openvpn
 OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
-# OPENVPN_CLIENT_CONFIG_DIR=${OPENVPN_CLIENT_CONFIG_DIR:-/etc/openvpn/ccd}
-# OPENVPN_STATUS_FILE=${OPENVPN_STATUS_FILE:-}
-# OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS={$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS:-10}
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
@@ -60,10 +57,6 @@ iptables -L -nv -t nat
 output "Generating command line"
 set "$OPENVPN" --cd /etc/openvpn
 set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
-# set "$@" --client-config-dir "$OPENVPN_CLIENT_CONFIG_DIR"
-if [ -n "$OPENVPN_STATUS_FILE" ]; then
-    set "$@" --status "$OPENVPN_STATUS_FILE" "$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS"
-fi
 
 # Exec
 ARGS="$@"

--- a/variants/v2.4.4-alpine-3.6/docker-entrypoint.sh
+++ b/variants/v2.4.4-alpine-3.6/docker-entrypoint.sh
@@ -13,9 +13,6 @@ error() {
 # Env vars
 OPENVPN=openvpn
 OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
-# OPENVPN_CLIENT_CONFIG_DIR=${OPENVPN_CLIENT_CONFIG_DIR:-/etc/openvpn/ccd}
-# OPENVPN_STATUS_FILE=${OPENVPN_STATUS_FILE:-}
-# OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS={$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS:-10}
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
@@ -60,10 +57,6 @@ iptables -L -nv -t nat
 output "Generating command line"
 set "$OPENVPN" --cd /etc/openvpn
 set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
-# set "$@" --client-config-dir "$OPENVPN_CLIENT_CONFIG_DIR"
-if [ -n "$OPENVPN_STATUS_FILE" ]; then
-    set "$@" --status "$OPENVPN_STATUS_FILE" "$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS"
-fi
 
 # Exec
 ARGS="$@"

--- a/variants/v2.4.4-alpine-3.7/docker-entrypoint.sh
+++ b/variants/v2.4.4-alpine-3.7/docker-entrypoint.sh
@@ -13,9 +13,6 @@ error() {
 # Env vars
 OPENVPN=openvpn
 OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
-# OPENVPN_CLIENT_CONFIG_DIR=${OPENVPN_CLIENT_CONFIG_DIR:-/etc/openvpn/ccd}
-# OPENVPN_STATUS_FILE=${OPENVPN_STATUS_FILE:-}
-# OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS={$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS:-10}
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
@@ -60,10 +57,6 @@ iptables -L -nv -t nat
 output "Generating command line"
 set "$OPENVPN" --cd /etc/openvpn
 set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
-# set "$@" --client-config-dir "$OPENVPN_CLIENT_CONFIG_DIR"
-if [ -n "$OPENVPN_STATUS_FILE" ]; then
-    set "$@" --status "$OPENVPN_STATUS_FILE" "$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS"
-fi
 
 # Exec
 ARGS="$@"

--- a/variants/v2.4.6-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v2.4.6-alpine-3.8/docker-entrypoint.sh
@@ -13,9 +13,6 @@ error() {
 # Env vars
 OPENVPN=openvpn
 OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
-# OPENVPN_CLIENT_CONFIG_DIR=${OPENVPN_CLIENT_CONFIG_DIR:-/etc/openvpn/ccd}
-# OPENVPN_STATUS_FILE=${OPENVPN_STATUS_FILE:-}
-# OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS={$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS:-10}
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
@@ -60,10 +57,6 @@ iptables -L -nv -t nat
 output "Generating command line"
 set "$OPENVPN" --cd /etc/openvpn
 set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
-# set "$@" --client-config-dir "$OPENVPN_CLIENT_CONFIG_DIR"
-if [ -n "$OPENVPN_STATUS_FILE" ]; then
-    set "$@" --status "$OPENVPN_STATUS_FILE" "$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS"
-fi
 
 # Exec
 ARGS="$@"

--- a/variants/v2.4.6-alpine-3.9/docker-entrypoint.sh
+++ b/variants/v2.4.6-alpine-3.9/docker-entrypoint.sh
@@ -13,9 +13,6 @@ error() {
 # Env vars
 OPENVPN=openvpn
 OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
-# OPENVPN_CLIENT_CONFIG_DIR=${OPENVPN_CLIENT_CONFIG_DIR:-/etc/openvpn/ccd}
-# OPENVPN_STATUS_FILE=${OPENVPN_STATUS_FILE:-}
-# OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS={$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS:-10}
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
@@ -60,10 +57,6 @@ iptables -L -nv -t nat
 output "Generating command line"
 set "$OPENVPN" --cd /etc/openvpn
 set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
-# set "$@" --client-config-dir "$OPENVPN_CLIENT_CONFIG_DIR"
-if [ -n "$OPENVPN_STATUS_FILE" ]; then
-    set "$@" --status "$OPENVPN_STATUS_FILE" "$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS"
-fi
 
 # Exec
 ARGS="$@"

--- a/variants/v2.5.6-alpine-3.13/docker-entrypoint.sh
+++ b/variants/v2.5.6-alpine-3.13/docker-entrypoint.sh
@@ -13,9 +13,6 @@ error() {
 # Env vars
 OPENVPN=openvpn
 OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
-# OPENVPN_CLIENT_CONFIG_DIR=${OPENVPN_CLIENT_CONFIG_DIR:-/etc/openvpn/ccd}
-# OPENVPN_STATUS_FILE=${OPENVPN_STATUS_FILE:-}
-# OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS={$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS:-10}
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
@@ -60,10 +57,6 @@ iptables -L -nv -t nat
 output "Generating command line"
 set "$OPENVPN" --cd /etc/openvpn
 set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
-# set "$@" --client-config-dir "$OPENVPN_CLIENT_CONFIG_DIR"
-if [ -n "$OPENVPN_STATUS_FILE" ]; then
-    set "$@" --status "$OPENVPN_STATUS_FILE" "$OPENVPN_STATUS_FILE_WRITE_FREQUENCY_SECONDS"
-fi
 
 # Exec
 ARGS="$@"


### PR DESCRIPTION
These can be controlled in the config file.