### PR TITLE
Feature (config): Add `NAT_MASQUERADE` environment variable to disable provisioning of `MASQUERADE` `iptables` rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ The defaults should work, so that there should be no need to specify any environ
 | Environment variables | Description | Default Value |
 |:-------:|:-------:|:-------:|
 | `OPENVPN_SERVER_CONFIG_FILE` | Absolute path to the server config | `/etc/openvpn/server.conf` |
-| `OPENVPN_ROUTES` | Space-delimited CIDRs to add iptables `POSTROUTING` NAT rules, performed only when `NAT` is `1` | `192.168.50.0/24 192.168.51.0/24` |
-| `NAT` | Whether to use NAT. `0` to disable. `1` to enable. If NAT is enabled, iptables `POSTROUTING` rules will be provisioned | `1` |
+| `OPENVPN_ROUTES` | Space-delimited CIDRs to add iptables `POSTROUTING` `MASQUERADE` rules, performed only when `NAT=1` and `NAT_MASQUERADE=1` | `192.168.50.0/24 192.168.51.0/24` |
+| `NAT` | Whether to use NAT. `0` to disable. `1` to enable. | `1` |
 | `NAT_INTERFACE` | Interface on which to use NAT. E.g. `eth0` | `eth0` |
+| `NAT_MASQUERADE` | Whether to add iptables `POSTROUTING` `MASQUERADE` rules, if `NAT=1`. `0` to disable. `1` to enable. Disable this if running as a client. | `1` |
 | `CUSTOM_FIREWALL_SCRIPT` | Full path to a custom script for firewall. If present, this script is executed before any other `iptables` rules are provisioned | `/etc/openvpn/firewall.sh` |
 
 ## `docker-entrypoint.sh`

--- a/generate/templates/README.md.ps1
+++ b/generate/templates/README.md.ps1
@@ -57,9 +57,10 @@ The defaults should work, so that there should be no need to specify any environ
 | Environment variables | Description | Default Value |
 |:-------:|:-------:|:-------:|
 | `OPENVPN_SERVER_CONFIG_FILE` | Absolute path to the server config | `/etc/openvpn/server.conf` |
-| `OPENVPN_ROUTES` | Space-delimited CIDRs to add iptables `POSTROUTING` NAT rules, performed only when `NAT` is `1` | `192.168.50.0/24 192.168.51.0/24` |
-| `NAT` | Whether to use NAT. `0` to disable. `1` to enable. If NAT is enabled, iptables `POSTROUTING` rules will be provisioned | `1` |
+| `OPENVPN_ROUTES` | Space-delimited CIDRs to add iptables `POSTROUTING` `MASQUERADE` rules, performed only when `NAT=1` and `NAT_MASQUERADE=1` | `192.168.50.0/24 192.168.51.0/24` |
+| `NAT` | Whether to use NAT. `0` to disable. `1` to enable. | `1` |
 | `NAT_INTERFACE` | Interface on which to use NAT. E.g. `eth0` | `eth0` |
+| `NAT_MASQUERADE` | Whether to add iptables `POSTROUTING` `MASQUERADE` rules, if `NAT=1`. `0` to disable. `1` to enable. Disable this if running as a client. | `1` |
 | `CUSTOM_FIREWALL_SCRIPT` | Full path to a custom script for firewall. If present, this script is executed before any other `iptables` rules are provisioned | `/etc/openvpn/firewall.sh` |
 
 ## `docker-entrypoint.sh`

--- a/variants/v2.3.18-alpine-3.3/docker-entrypoint.sh
+++ b/variants/v2.3.18-alpine-3.3/docker-entrypoint.sh
@@ -15,6 +15,7 @@ OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.con
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
 
 # Provision
@@ -33,14 +34,19 @@ if [ "$NAT" = 1 ]; then
     output "NAT is enabled"
     output "Provisioning NAT iptables rules"
     output "NAT_INTERFACE: $NAT_INTERFACE"
-    iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
-    if [ -n "$OPENVPN_ROUTES" ]; then
-        output "Provisioning NAT iptables rules for OPENVPN_ROUTES"
-        for r in $OPENVPN_ROUTES; do
-            iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
-        done
+    if [ "$NAT_MASQUERADE" = 1 ]; then
+        output "NAT_MASQUERADE is enabled"
+        iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+        if [ -n "$OPENVPN_ROUTES" ]; then
+            output "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+            for r in $OPENVPN_ROUTES; do
+                iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+            done
+        else
+            output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        fi
     else
-        output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        output "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
     fi
 else
     output "NAT is disabled."

--- a/variants/v2.3.18-alpine-3.4/docker-entrypoint.sh
+++ b/variants/v2.3.18-alpine-3.4/docker-entrypoint.sh
@@ -15,6 +15,7 @@ OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.con
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
 
 # Provision
@@ -33,14 +34,19 @@ if [ "$NAT" = 1 ]; then
     output "NAT is enabled"
     output "Provisioning NAT iptables rules"
     output "NAT_INTERFACE: $NAT_INTERFACE"
-    iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
-    if [ -n "$OPENVPN_ROUTES" ]; then
-        output "Provisioning NAT iptables rules for OPENVPN_ROUTES"
-        for r in $OPENVPN_ROUTES; do
-            iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
-        done
+    if [ "$NAT_MASQUERADE" = 1 ]; then
+        output "NAT_MASQUERADE is enabled"
+        iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+        if [ -n "$OPENVPN_ROUTES" ]; then
+            output "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+            for r in $OPENVPN_ROUTES; do
+                iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+            done
+        else
+            output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        fi
     else
-        output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        output "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
     fi
 else
     output "NAT is disabled."

--- a/variants/v2.3.18-alpine-3.5/docker-entrypoint.sh
+++ b/variants/v2.3.18-alpine-3.5/docker-entrypoint.sh
@@ -15,6 +15,7 @@ OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.con
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
 
 # Provision
@@ -33,14 +34,19 @@ if [ "$NAT" = 1 ]; then
     output "NAT is enabled"
     output "Provisioning NAT iptables rules"
     output "NAT_INTERFACE: $NAT_INTERFACE"
-    iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
-    if [ -n "$OPENVPN_ROUTES" ]; then
-        output "Provisioning NAT iptables rules for OPENVPN_ROUTES"
-        for r in $OPENVPN_ROUTES; do
-            iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
-        done
+    if [ "$NAT_MASQUERADE" = 1 ]; then
+        output "NAT_MASQUERADE is enabled"
+        iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+        if [ -n "$OPENVPN_ROUTES" ]; then
+            output "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+            for r in $OPENVPN_ROUTES; do
+                iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+            done
+        else
+            output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        fi
     else
-        output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        output "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
     fi
 else
     output "NAT is disabled."

--- a/variants/v2.4.11-alpine-3.10/docker-entrypoint.sh
+++ b/variants/v2.4.11-alpine-3.10/docker-entrypoint.sh
@@ -15,6 +15,7 @@ OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.con
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
 
 # Provision
@@ -33,14 +34,19 @@ if [ "$NAT" = 1 ]; then
     output "NAT is enabled"
     output "Provisioning NAT iptables rules"
     output "NAT_INTERFACE: $NAT_INTERFACE"
-    iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
-    if [ -n "$OPENVPN_ROUTES" ]; then
-        output "Provisioning NAT iptables rules for OPENVPN_ROUTES"
-        for r in $OPENVPN_ROUTES; do
-            iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
-        done
+    if [ "$NAT_MASQUERADE" = 1 ]; then
+        output "NAT_MASQUERADE is enabled"
+        iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+        if [ -n "$OPENVPN_ROUTES" ]; then
+            output "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+            for r in $OPENVPN_ROUTES; do
+                iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+            done
+        else
+            output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        fi
     else
-        output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        output "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
     fi
 else
     output "NAT is disabled."

--- a/variants/v2.4.11-alpine-3.11/docker-entrypoint.sh
+++ b/variants/v2.4.11-alpine-3.11/docker-entrypoint.sh
@@ -15,6 +15,7 @@ OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.con
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
 
 # Provision
@@ -33,14 +34,19 @@ if [ "$NAT" = 1 ]; then
     output "NAT is enabled"
     output "Provisioning NAT iptables rules"
     output "NAT_INTERFACE: $NAT_INTERFACE"
-    iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
-    if [ -n "$OPENVPN_ROUTES" ]; then
-        output "Provisioning NAT iptables rules for OPENVPN_ROUTES"
-        for r in $OPENVPN_ROUTES; do
-            iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
-        done
+    if [ "$NAT_MASQUERADE" = 1 ]; then
+        output "NAT_MASQUERADE is enabled"
+        iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+        if [ -n "$OPENVPN_ROUTES" ]; then
+            output "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+            for r in $OPENVPN_ROUTES; do
+                iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+            done
+        else
+            output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        fi
     else
-        output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        output "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
     fi
 else
     output "NAT is disabled."

--- a/variants/v2.4.12-alpine-3.12/docker-entrypoint.sh
+++ b/variants/v2.4.12-alpine-3.12/docker-entrypoint.sh
@@ -15,6 +15,7 @@ OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.con
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
 
 # Provision
@@ -33,14 +34,19 @@ if [ "$NAT" = 1 ]; then
     output "NAT is enabled"
     output "Provisioning NAT iptables rules"
     output "NAT_INTERFACE: $NAT_INTERFACE"
-    iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
-    if [ -n "$OPENVPN_ROUTES" ]; then
-        output "Provisioning NAT iptables rules for OPENVPN_ROUTES"
-        for r in $OPENVPN_ROUTES; do
-            iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
-        done
+    if [ "$NAT_MASQUERADE" = 1 ]; then
+        output "NAT_MASQUERADE is enabled"
+        iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+        if [ -n "$OPENVPN_ROUTES" ]; then
+            output "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+            for r in $OPENVPN_ROUTES; do
+                iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+            done
+        else
+            output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        fi
     else
-        output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        output "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
     fi
 else
     output "NAT is disabled."

--- a/variants/v2.4.4-alpine-3.6/docker-entrypoint.sh
+++ b/variants/v2.4.4-alpine-3.6/docker-entrypoint.sh
@@ -15,6 +15,7 @@ OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.con
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
 
 # Provision
@@ -33,14 +34,19 @@ if [ "$NAT" = 1 ]; then
     output "NAT is enabled"
     output "Provisioning NAT iptables rules"
     output "NAT_INTERFACE: $NAT_INTERFACE"
-    iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
-    if [ -n "$OPENVPN_ROUTES" ]; then
-        output "Provisioning NAT iptables rules for OPENVPN_ROUTES"
-        for r in $OPENVPN_ROUTES; do
-            iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
-        done
+    if [ "$NAT_MASQUERADE" = 1 ]; then
+        output "NAT_MASQUERADE is enabled"
+        iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+        if [ -n "$OPENVPN_ROUTES" ]; then
+            output "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+            for r in $OPENVPN_ROUTES; do
+                iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+            done
+        else
+            output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        fi
     else
-        output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        output "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
     fi
 else
     output "NAT is disabled."

--- a/variants/v2.4.4-alpine-3.7/docker-entrypoint.sh
+++ b/variants/v2.4.4-alpine-3.7/docker-entrypoint.sh
@@ -15,6 +15,7 @@ OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.con
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
 
 # Provision
@@ -33,14 +34,19 @@ if [ "$NAT" = 1 ]; then
     output "NAT is enabled"
     output "Provisioning NAT iptables rules"
     output "NAT_INTERFACE: $NAT_INTERFACE"
-    iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
-    if [ -n "$OPENVPN_ROUTES" ]; then
-        output "Provisioning NAT iptables rules for OPENVPN_ROUTES"
-        for r in $OPENVPN_ROUTES; do
-            iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
-        done
+    if [ "$NAT_MASQUERADE" = 1 ]; then
+        output "NAT_MASQUERADE is enabled"
+        iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+        if [ -n "$OPENVPN_ROUTES" ]; then
+            output "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+            for r in $OPENVPN_ROUTES; do
+                iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+            done
+        else
+            output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        fi
     else
-        output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        output "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
     fi
 else
     output "NAT is disabled."

--- a/variants/v2.4.6-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v2.4.6-alpine-3.8/docker-entrypoint.sh
@@ -15,6 +15,7 @@ OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.con
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
 
 # Provision
@@ -33,14 +34,19 @@ if [ "$NAT" = 1 ]; then
     output "NAT is enabled"
     output "Provisioning NAT iptables rules"
     output "NAT_INTERFACE: $NAT_INTERFACE"
-    iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
-    if [ -n "$OPENVPN_ROUTES" ]; then
-        output "Provisioning NAT iptables rules for OPENVPN_ROUTES"
-        for r in $OPENVPN_ROUTES; do
-            iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
-        done
+    if [ "$NAT_MASQUERADE" = 1 ]; then
+        output "NAT_MASQUERADE is enabled"
+        iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+        if [ -n "$OPENVPN_ROUTES" ]; then
+            output "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+            for r in $OPENVPN_ROUTES; do
+                iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+            done
+        else
+            output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        fi
     else
-        output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        output "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
     fi
 else
     output "NAT is disabled."

--- a/variants/v2.4.6-alpine-3.9/docker-entrypoint.sh
+++ b/variants/v2.4.6-alpine-3.9/docker-entrypoint.sh
@@ -15,6 +15,7 @@ OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.con
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
 
 # Provision
@@ -33,14 +34,19 @@ if [ "$NAT" = 1 ]; then
     output "NAT is enabled"
     output "Provisioning NAT iptables rules"
     output "NAT_INTERFACE: $NAT_INTERFACE"
-    iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
-    if [ -n "$OPENVPN_ROUTES" ]; then
-        output "Provisioning NAT iptables rules for OPENVPN_ROUTES"
-        for r in $OPENVPN_ROUTES; do
-            iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
-        done
+    if [ "$NAT_MASQUERADE" = 1 ]; then
+        output "NAT_MASQUERADE is enabled"
+        iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+        if [ -n "$OPENVPN_ROUTES" ]; then
+            output "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+            for r in $OPENVPN_ROUTES; do
+                iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+            done
+        else
+            output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        fi
     else
-        output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        output "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
     fi
 else
     output "NAT is disabled."

--- a/variants/v2.5.6-alpine-3.13/docker-entrypoint.sh
+++ b/variants/v2.5.6-alpine-3.13/docker-entrypoint.sh
@@ -15,6 +15,7 @@ OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.con
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
 
 # Provision
@@ -33,14 +34,19 @@ if [ "$NAT" = 1 ]; then
     output "NAT is enabled"
     output "Provisioning NAT iptables rules"
     output "NAT_INTERFACE: $NAT_INTERFACE"
-    iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
-    if [ -n "$OPENVPN_ROUTES" ]; then
-        output "Provisioning NAT iptables rules for OPENVPN_ROUTES"
-        for r in $OPENVPN_ROUTES; do
-            iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
-        done
+    if [ "$NAT_MASQUERADE" = 1 ]; then
+        output "NAT_MASQUERADE is enabled"
+        iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+        if [ -n "$OPENVPN_ROUTES" ]; then
+            output "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+            for r in $OPENVPN_ROUTES; do
+                iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+            done
+        else
+            output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        fi
     else
-        output "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+        output "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
     fi
 else
     output "NAT is disabled."


### PR DESCRIPTION
`MASQUERADE` is generally only needed when `openvpn` is running as a server, but not needed as a client. This environment variable is useful to disable `MASQUERADE` for clients.