### PR TITLE
Refactor: Add `OPENVPN_CONFIG_FILE` environment variable and deprecate `OPENVPN_SERVER_CONFIG_FILE`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The defaults should work, so that there should be no need to specify any environ
 
 | Environment variables | Description | Default Value |
 |:-------:|:-------:|:-------:|
-| `OPENVPN_SERVER_CONFIG_FILE` | Absolute path to the server config | `/etc/openvpn/server.conf` |
+| `OPENVPN_CONFIG_FILE` | Absolute path to the server config | `/etc/openvpn/server.conf` |
 | `OPENVPN_ROUTES` | Space-delimited CIDRs to add iptables `POSTROUTING` `MASQUERADE` rules, performed only when `NAT=1` and `NAT_MASQUERADE=1` | `192.168.50.0/24 192.168.51.0/24` |
 | `NAT` | Whether to use NAT. `0` to disable. `1` to enable. | `1` |
 | `NAT_INTERFACE` | Interface on which to use NAT. E.g. `eth0` | `eth0` |

--- a/generate/templates/README.md.ps1
+++ b/generate/templates/README.md.ps1
@@ -56,7 +56,7 @@ The defaults should work, so that there should be no need to specify any environ
 
 | Environment variables | Description | Default Value |
 |:-------:|:-------:|:-------:|
-| `OPENVPN_SERVER_CONFIG_FILE` | Absolute path to the server config | `/etc/openvpn/server.conf` |
+| `OPENVPN_CONFIG_FILE` | Absolute path to the server config | `/etc/openvpn/server.conf` |
 | `OPENVPN_ROUTES` | Space-delimited CIDRs to add iptables `POSTROUTING` `MASQUERADE` rules, performed only when `NAT=1` and `NAT_MASQUERADE=1` | `192.168.50.0/24 192.168.51.0/24` |
 | `NAT` | Whether to use NAT. `0` to disable. `1` to enable. | `1` |
 | `NAT_INTERFACE` | Interface on which to use NAT. E.g. `eth0` | `eth0` |

--- a/generate/templates/docker-compose.yml.ps1
+++ b/generate/templates/docker-compose.yml.ps1
@@ -1,17 +1,35 @@
 @"
 version: '2.1'
 services:
-  openvpn:
-    container_name: openvpn
+  openvpn-server:
     image: theohbrothers/docker-openvpn:$( $VARIANT['tag'] )
     environment:
-      - OPENVPN_SERVER_CONFIG_FILE=/etc/openvpn/server.conf
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
       # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
     volumes:
       - ./openvpn/server.conf:/etc/openvpn/server.conf
       # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     ports:
       - "1194:1194/udp"
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    image: theohbrothers/docker-openvpn:$( $VARIANT['tag'] )
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     cap_add:
       - NET_ADMIN
     # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls

--- a/generate/templates/docker-entrypoint.sh.ps1
+++ b/generate/templates/docker-entrypoint.sh.ps1
@@ -12,12 +12,19 @@ error() {
 }
 
 # Env vars
-OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
 NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    output "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
 
 # Provision
 output "Provisioning tun device"
@@ -62,7 +69,7 @@ iptables -L -nv -t nat
 # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
 output "Generating command line"
 set openvpn --cd /etc/openvpn
-set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
+set "$@" --config "$OPENVPN_CONFIG_FILE"
 
 # Exec
 ARGS="$@"

--- a/variants/v2.3.18-alpine-3.3/docker-compose.yml
+++ b/variants/v2.3.18-alpine-3.3/docker-compose.yml
@@ -1,16 +1,34 @@
 version: '2.1'
 services:
-  openvpn:
-    container_name: openvpn
+  openvpn-server:
     image: theohbrothers/docker-openvpn:v2.3.18-alpine-3.3
     environment:
-      - OPENVPN_SERVER_CONFIG_FILE=/etc/openvpn/server.conf
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
       # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
     volumes:
       - ./openvpn/server.conf:/etc/openvpn/server.conf
       # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     ports:
       - "1194:1194/udp"
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    image: theohbrothers/docker-openvpn:v2.3.18-alpine-3.3
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     cap_add:
       - NET_ADMIN
     # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls

--- a/variants/v2.3.18-alpine-3.3/docker-entrypoint.sh
+++ b/variants/v2.3.18-alpine-3.3/docker-entrypoint.sh
@@ -11,12 +11,19 @@ error() {
 }
 
 # Env vars
-OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
 NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    output "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
 
 # Provision
 output "Provisioning tun device"
@@ -61,7 +68,7 @@ iptables -L -nv -t nat
 # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
 output "Generating command line"
 set openvpn --cd /etc/openvpn
-set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
+set "$@" --config "$OPENVPN_CONFIG_FILE"
 
 # Exec
 ARGS="$@"

--- a/variants/v2.3.18-alpine-3.4/docker-compose.yml
+++ b/variants/v2.3.18-alpine-3.4/docker-compose.yml
@@ -1,16 +1,34 @@
 version: '2.1'
 services:
-  openvpn:
-    container_name: openvpn
+  openvpn-server:
     image: theohbrothers/docker-openvpn:v2.3.18-alpine-3.4
     environment:
-      - OPENVPN_SERVER_CONFIG_FILE=/etc/openvpn/server.conf
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
       # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
     volumes:
       - ./openvpn/server.conf:/etc/openvpn/server.conf
       # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     ports:
       - "1194:1194/udp"
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    image: theohbrothers/docker-openvpn:v2.3.18-alpine-3.4
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     cap_add:
       - NET_ADMIN
     # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls

--- a/variants/v2.3.18-alpine-3.4/docker-entrypoint.sh
+++ b/variants/v2.3.18-alpine-3.4/docker-entrypoint.sh
@@ -11,12 +11,19 @@ error() {
 }
 
 # Env vars
-OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
 NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    output "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
 
 # Provision
 output "Provisioning tun device"
@@ -61,7 +68,7 @@ iptables -L -nv -t nat
 # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
 output "Generating command line"
 set openvpn --cd /etc/openvpn
-set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
+set "$@" --config "$OPENVPN_CONFIG_FILE"
 
 # Exec
 ARGS="$@"

--- a/variants/v2.3.18-alpine-3.5/docker-compose.yml
+++ b/variants/v2.3.18-alpine-3.5/docker-compose.yml
@@ -1,16 +1,34 @@
 version: '2.1'
 services:
-  openvpn:
-    container_name: openvpn
+  openvpn-server:
     image: theohbrothers/docker-openvpn:v2.3.18-alpine-3.5
     environment:
-      - OPENVPN_SERVER_CONFIG_FILE=/etc/openvpn/server.conf
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
       # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
     volumes:
       - ./openvpn/server.conf:/etc/openvpn/server.conf
       # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     ports:
       - "1194:1194/udp"
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    image: theohbrothers/docker-openvpn:v2.3.18-alpine-3.5
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     cap_add:
       - NET_ADMIN
     # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls

--- a/variants/v2.3.18-alpine-3.5/docker-entrypoint.sh
+++ b/variants/v2.3.18-alpine-3.5/docker-entrypoint.sh
@@ -11,12 +11,19 @@ error() {
 }
 
 # Env vars
-OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
 NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    output "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
 
 # Provision
 output "Provisioning tun device"
@@ -61,7 +68,7 @@ iptables -L -nv -t nat
 # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
 output "Generating command line"
 set openvpn --cd /etc/openvpn
-set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
+set "$@" --config "$OPENVPN_CONFIG_FILE"
 
 # Exec
 ARGS="$@"

--- a/variants/v2.4.11-alpine-3.10/docker-compose.yml
+++ b/variants/v2.4.11-alpine-3.10/docker-compose.yml
@@ -1,16 +1,34 @@
 version: '2.1'
 services:
-  openvpn:
-    container_name: openvpn
+  openvpn-server:
     image: theohbrothers/docker-openvpn:v2.4.11-alpine-3.10
     environment:
-      - OPENVPN_SERVER_CONFIG_FILE=/etc/openvpn/server.conf
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
       # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
     volumes:
       - ./openvpn/server.conf:/etc/openvpn/server.conf
       # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     ports:
       - "1194:1194/udp"
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    image: theohbrothers/docker-openvpn:v2.4.11-alpine-3.10
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     cap_add:
       - NET_ADMIN
     # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls

--- a/variants/v2.4.11-alpine-3.10/docker-entrypoint.sh
+++ b/variants/v2.4.11-alpine-3.10/docker-entrypoint.sh
@@ -11,12 +11,19 @@ error() {
 }
 
 # Env vars
-OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
 NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    output "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
 
 # Provision
 output "Provisioning tun device"
@@ -61,7 +68,7 @@ iptables -L -nv -t nat
 # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
 output "Generating command line"
 set openvpn --cd /etc/openvpn
-set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
+set "$@" --config "$OPENVPN_CONFIG_FILE"
 
 # Exec
 ARGS="$@"

--- a/variants/v2.4.11-alpine-3.11/docker-compose.yml
+++ b/variants/v2.4.11-alpine-3.11/docker-compose.yml
@@ -1,16 +1,34 @@
 version: '2.1'
 services:
-  openvpn:
-    container_name: openvpn
+  openvpn-server:
     image: theohbrothers/docker-openvpn:v2.4.11-alpine-3.11
     environment:
-      - OPENVPN_SERVER_CONFIG_FILE=/etc/openvpn/server.conf
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
       # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
     volumes:
       - ./openvpn/server.conf:/etc/openvpn/server.conf
       # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     ports:
       - "1194:1194/udp"
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    image: theohbrothers/docker-openvpn:v2.4.11-alpine-3.11
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     cap_add:
       - NET_ADMIN
     # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls

--- a/variants/v2.4.11-alpine-3.11/docker-entrypoint.sh
+++ b/variants/v2.4.11-alpine-3.11/docker-entrypoint.sh
@@ -11,12 +11,19 @@ error() {
 }
 
 # Env vars
-OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
 NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    output "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
 
 # Provision
 output "Provisioning tun device"
@@ -61,7 +68,7 @@ iptables -L -nv -t nat
 # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
 output "Generating command line"
 set openvpn --cd /etc/openvpn
-set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
+set "$@" --config "$OPENVPN_CONFIG_FILE"
 
 # Exec
 ARGS="$@"

--- a/variants/v2.4.12-alpine-3.12/docker-compose.yml
+++ b/variants/v2.4.12-alpine-3.12/docker-compose.yml
@@ -1,16 +1,34 @@
 version: '2.1'
 services:
-  openvpn:
-    container_name: openvpn
+  openvpn-server:
     image: theohbrothers/docker-openvpn:v2.4.12-alpine-3.12
     environment:
-      - OPENVPN_SERVER_CONFIG_FILE=/etc/openvpn/server.conf
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
       # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
     volumes:
       - ./openvpn/server.conf:/etc/openvpn/server.conf
       # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     ports:
       - "1194:1194/udp"
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    image: theohbrothers/docker-openvpn:v2.4.12-alpine-3.12
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     cap_add:
       - NET_ADMIN
     # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls

--- a/variants/v2.4.12-alpine-3.12/docker-entrypoint.sh
+++ b/variants/v2.4.12-alpine-3.12/docker-entrypoint.sh
@@ -11,12 +11,19 @@ error() {
 }
 
 # Env vars
-OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
 NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    output "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
 
 # Provision
 output "Provisioning tun device"
@@ -61,7 +68,7 @@ iptables -L -nv -t nat
 # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
 output "Generating command line"
 set openvpn --cd /etc/openvpn
-set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
+set "$@" --config "$OPENVPN_CONFIG_FILE"
 
 # Exec
 ARGS="$@"

--- a/variants/v2.4.4-alpine-3.6/docker-compose.yml
+++ b/variants/v2.4.4-alpine-3.6/docker-compose.yml
@@ -1,16 +1,34 @@
 version: '2.1'
 services:
-  openvpn:
-    container_name: openvpn
+  openvpn-server:
     image: theohbrothers/docker-openvpn:v2.4.4-alpine-3.6
     environment:
-      - OPENVPN_SERVER_CONFIG_FILE=/etc/openvpn/server.conf
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
       # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
     volumes:
       - ./openvpn/server.conf:/etc/openvpn/server.conf
       # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     ports:
       - "1194:1194/udp"
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    image: theohbrothers/docker-openvpn:v2.4.4-alpine-3.6
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     cap_add:
       - NET_ADMIN
     # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls

--- a/variants/v2.4.4-alpine-3.6/docker-entrypoint.sh
+++ b/variants/v2.4.4-alpine-3.6/docker-entrypoint.sh
@@ -11,12 +11,19 @@ error() {
 }
 
 # Env vars
-OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
 NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    output "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
 
 # Provision
 output "Provisioning tun device"
@@ -61,7 +68,7 @@ iptables -L -nv -t nat
 # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
 output "Generating command line"
 set openvpn --cd /etc/openvpn
-set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
+set "$@" --config "$OPENVPN_CONFIG_FILE"
 
 # Exec
 ARGS="$@"

--- a/variants/v2.4.4-alpine-3.7/docker-compose.yml
+++ b/variants/v2.4.4-alpine-3.7/docker-compose.yml
@@ -1,16 +1,34 @@
 version: '2.1'
 services:
-  openvpn:
-    container_name: openvpn
+  openvpn-server:
     image: theohbrothers/docker-openvpn:v2.4.4-alpine-3.7
     environment:
-      - OPENVPN_SERVER_CONFIG_FILE=/etc/openvpn/server.conf
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
       # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
     volumes:
       - ./openvpn/server.conf:/etc/openvpn/server.conf
       # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     ports:
       - "1194:1194/udp"
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    image: theohbrothers/docker-openvpn:v2.4.4-alpine-3.7
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     cap_add:
       - NET_ADMIN
     # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls

--- a/variants/v2.4.4-alpine-3.7/docker-entrypoint.sh
+++ b/variants/v2.4.4-alpine-3.7/docker-entrypoint.sh
@@ -11,12 +11,19 @@ error() {
 }
 
 # Env vars
-OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
 NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    output "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
 
 # Provision
 output "Provisioning tun device"
@@ -61,7 +68,7 @@ iptables -L -nv -t nat
 # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
 output "Generating command line"
 set openvpn --cd /etc/openvpn
-set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
+set "$@" --config "$OPENVPN_CONFIG_FILE"
 
 # Exec
 ARGS="$@"

--- a/variants/v2.4.6-alpine-3.8/docker-compose.yml
+++ b/variants/v2.4.6-alpine-3.8/docker-compose.yml
@@ -1,16 +1,34 @@
 version: '2.1'
 services:
-  openvpn:
-    container_name: openvpn
+  openvpn-server:
     image: theohbrothers/docker-openvpn:v2.4.6-alpine-3.8
     environment:
-      - OPENVPN_SERVER_CONFIG_FILE=/etc/openvpn/server.conf
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
       # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
     volumes:
       - ./openvpn/server.conf:/etc/openvpn/server.conf
       # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     ports:
       - "1194:1194/udp"
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    image: theohbrothers/docker-openvpn:v2.4.6-alpine-3.8
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     cap_add:
       - NET_ADMIN
     # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls

--- a/variants/v2.4.6-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v2.4.6-alpine-3.8/docker-entrypoint.sh
@@ -11,12 +11,19 @@ error() {
 }
 
 # Env vars
-OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
 NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    output "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
 
 # Provision
 output "Provisioning tun device"
@@ -61,7 +68,7 @@ iptables -L -nv -t nat
 # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
 output "Generating command line"
 set openvpn --cd /etc/openvpn
-set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
+set "$@" --config "$OPENVPN_CONFIG_FILE"
 
 # Exec
 ARGS="$@"

--- a/variants/v2.4.6-alpine-3.9/docker-compose.yml
+++ b/variants/v2.4.6-alpine-3.9/docker-compose.yml
@@ -1,16 +1,34 @@
 version: '2.1'
 services:
-  openvpn:
-    container_name: openvpn
+  openvpn-server:
     image: theohbrothers/docker-openvpn:v2.4.6-alpine-3.9
     environment:
-      - OPENVPN_SERVER_CONFIG_FILE=/etc/openvpn/server.conf
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
       # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
     volumes:
       - ./openvpn/server.conf:/etc/openvpn/server.conf
       # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     ports:
       - "1194:1194/udp"
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    image: theohbrothers/docker-openvpn:v2.4.6-alpine-3.9
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     cap_add:
       - NET_ADMIN
     # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls

--- a/variants/v2.4.6-alpine-3.9/docker-entrypoint.sh
+++ b/variants/v2.4.6-alpine-3.9/docker-entrypoint.sh
@@ -11,12 +11,19 @@ error() {
 }
 
 # Env vars
-OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
 NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    output "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
 
 # Provision
 output "Provisioning tun device"
@@ -61,7 +68,7 @@ iptables -L -nv -t nat
 # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
 output "Generating command line"
 set openvpn --cd /etc/openvpn
-set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
+set "$@" --config "$OPENVPN_CONFIG_FILE"
 
 # Exec
 ARGS="$@"

--- a/variants/v2.5.6-alpine-3.13/docker-compose.yml
+++ b/variants/v2.5.6-alpine-3.13/docker-compose.yml
@@ -1,16 +1,34 @@
 version: '2.1'
 services:
-  openvpn:
-    container_name: openvpn
+  openvpn-server:
     image: theohbrothers/docker-openvpn:v2.5.6-alpine-3.13
     environment:
-      - OPENVPN_SERVER_CONFIG_FILE=/etc/openvpn/server.conf
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
       # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
     volumes:
       - ./openvpn/server.conf:/etc/openvpn/server.conf
       # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     ports:
       - "1194:1194/udp"
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    image: theohbrothers/docker-openvpn:v2.5.6-alpine-3.13
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
     cap_add:
       - NET_ADMIN
     # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls

--- a/variants/v2.5.6-alpine-3.13/docker-entrypoint.sh
+++ b/variants/v2.5.6-alpine-3.13/docker-entrypoint.sh
@@ -11,12 +11,19 @@ error() {
 }
 
 # Env vars
-OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
 OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
 NAT=${NAT:-1}
 NAT_INTERFACE=${NAT_INTERFACE:-eth0}
 NAT_MASQUERADE=${NAT_MASQUERADE:-1}
 CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    output "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
 
 # Provision
 output "Provisioning tun device"
@@ -61,7 +68,7 @@ iptables -L -nv -t nat
 # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
 output "Generating command line"
 set openvpn --cd /etc/openvpn
-set "$@" --config "$OPENVPN_SERVER_CONFIG_FILE"
+set "$@" --config "$OPENVPN_CONFIG_FILE"
 
 # Exec
 ARGS="$@"


### PR DESCRIPTION
`OPENVPN_SERVER_CONFIG_FILE` implies only server `.conf` is supported. However, `openvpn` can also be run as a client.

Now `OPENVPN_CONFIG_FILE` is added to replace `OPENVPN_SERVER_CONFIG_FILE` for better clarity that both server or client `.conf` are supported. `OPENVPN_SERVER_CONFIG_FILE` environment variable is deprecated, but still supported.