### PR TITLE
Change: Remove `v` prefix from docker tags

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -79,7 +79,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-6-5-alpine-3-18
+      id: prep-2-6-5-alpine-3-18
       run: |
         set -e
 
@@ -92,7 +92,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.6.5-alpine-3.18"
+        VARIANT="2.6.5-alpine-3.18"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -102,45 +102,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.6.5-alpine-3.18 - Build (PRs)
+    - name: 2.6.5-alpine-3.18 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.6.5-alpine-3.18
+        context: variants/2.6.5-alpine-3.18
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-6-5-alpine-3-18.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-6-5-alpine-3-18.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-5-alpine-3-18.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-5-alpine-3-18.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.6.5-alpine-3.18 - Build and push (master)
+    - name: 2.6.5-alpine-3.18 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.6.5-alpine-3.18
+        context: variants/2.6.5-alpine-3.18
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-6-5-alpine-3-18.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-6-5-alpine-3-18.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-5-alpine-3-18.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-5-alpine-3-18.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.6.5-alpine-3.18 - Build and push (release)
+    - name: 2.6.5-alpine-3.18 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.6.5-alpine-3.18
+        context: variants/2.6.5-alpine-3.18
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-6-5-alpine-3-18.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-6-5-alpine-3-18.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-6-5-alpine-3-18.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-5-alpine-3-18.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-5-alpine-3-18.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-5-alpine-3-18.outputs.REF_SHA_VARIANT }}
           ${{ github.repository }}:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
@@ -199,7 +199,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-5-8-alpine-3-17
+      id: prep-2-5-8-alpine-3-17
       run: |
         set -e
 
@@ -212,7 +212,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.5.8-alpine-3.17"
+        VARIANT="2.5.8-alpine-3.17"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -222,45 +222,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.5.8-alpine-3.17 - Build (PRs)
+    - name: 2.5.8-alpine-3.17 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.5.8-alpine-3.17
+        context: variants/2.5.8-alpine-3.17
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-5-8-alpine-3-17.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-5-8-alpine-3-17.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-5-8-alpine-3-17.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-5-8-alpine-3-17.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.5.8-alpine-3.17 - Build and push (master)
+    - name: 2.5.8-alpine-3.17 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.5.8-alpine-3.17
+        context: variants/2.5.8-alpine-3.17
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-5-8-alpine-3-17.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-5-8-alpine-3-17.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-5-8-alpine-3-17.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-5-8-alpine-3-17.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.5.8-alpine-3.17 - Build and push (release)
+    - name: 2.5.8-alpine-3.17 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.5.8-alpine-3.17
+        context: variants/2.5.8-alpine-3.17
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-5-8-alpine-3-17.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-5-8-alpine-3-17.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-5-8-alpine-3-17.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-5-8-alpine-3-17.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-5-8-alpine-3-17.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-5-8-alpine-3-17.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -318,7 +318,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-4-12-alpine-3-12
+      id: prep-2-4-12-alpine-3-12
       run: |
         set -e
 
@@ -331,7 +331,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.4.12-alpine-3.12"
+        VARIANT="2.4.12-alpine-3.12"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -341,45 +341,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.4.12-alpine-3.12 - Build (PRs)
+    - name: 2.4.12-alpine-3.12 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.12-alpine-3.12
+        context: variants/2.4.12-alpine-3.12
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-12-alpine-3-12.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-12-alpine-3-12.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-12-alpine-3-12.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-12-alpine-3-12.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.12-alpine-3.12 - Build and push (master)
+    - name: 2.4.12-alpine-3.12 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.12-alpine-3.12
+        context: variants/2.4.12-alpine-3.12
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-12-alpine-3-12.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-12-alpine-3-12.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-12-alpine-3-12.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-12-alpine-3-12.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.12-alpine-3.12 - Build and push (release)
+    - name: 2.4.12-alpine-3.12 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.12-alpine-3.12
+        context: variants/2.4.12-alpine-3.12
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-12-alpine-3-12.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-12-alpine-3-12.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-12-alpine-3-12.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-12-alpine-3-12.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-12-alpine-3-12.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-12-alpine-3-12.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -437,7 +437,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-4-11-alpine-3-11
+      id: prep-2-4-11-alpine-3-11
       run: |
         set -e
 
@@ -450,7 +450,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.4.11-alpine-3.11"
+        VARIANT="2.4.11-alpine-3.11"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -460,51 +460,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.4.11-alpine-3.11 - Build (PRs)
+    - name: 2.4.11-alpine-3.11 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.11-alpine-3.11
+        context: variants/2.4.11-alpine-3.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-11-alpine-3-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-11-alpine-3-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-11-alpine-3-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-11-alpine-3-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.11-alpine-3.11 - Build and push (master)
+    - name: 2.4.11-alpine-3.11 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.11-alpine-3.11
+        context: variants/2.4.11-alpine-3.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-11-alpine-3-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-11-alpine-3-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-11-alpine-3-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-11-alpine-3-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.11-alpine-3.11 - Build and push (release)
+    - name: 2.4.11-alpine-3.11 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.11-alpine-3.11
+        context: variants/2.4.11-alpine-3.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-11-alpine-3-11.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-11-alpine-3-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-11-alpine-3-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-11-alpine-3-11.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-11-alpine-3-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-11-alpine-3-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-4-11-alpine-3-10
+      id: prep-2-4-11-alpine-3-10
       run: |
         set -e
 
@@ -517,7 +517,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.4.11-alpine-3.10"
+        VARIANT="2.4.11-alpine-3.10"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -527,45 +527,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.4.11-alpine-3.10 - Build (PRs)
+    - name: 2.4.11-alpine-3.10 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.11-alpine-3.10
+        context: variants/2.4.11-alpine-3.10
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-11-alpine-3-10.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-11-alpine-3-10.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-11-alpine-3-10.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-11-alpine-3-10.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.11-alpine-3.10 - Build and push (master)
+    - name: 2.4.11-alpine-3.10 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.11-alpine-3.10
+        context: variants/2.4.11-alpine-3.10
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-11-alpine-3-10.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-11-alpine-3-10.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-11-alpine-3-10.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-11-alpine-3-10.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.11-alpine-3.10 - Build and push (release)
+    - name: 2.4.11-alpine-3.10 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.11-alpine-3.10
+        context: variants/2.4.11-alpine-3.10
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-11-alpine-3-10.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-11-alpine-3-10.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-11-alpine-3-10.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-11-alpine-3-10.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-11-alpine-3-10.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-11-alpine-3-10.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -623,7 +623,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-4-6-alpine-3-9
+      id: prep-2-4-6-alpine-3-9
       run: |
         set -e
 
@@ -636,7 +636,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.4.6-alpine-3.9"
+        VARIANT="2.4.6-alpine-3.9"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -646,51 +646,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.4.6-alpine-3.9 - Build (PRs)
+    - name: 2.4.6-alpine-3.9 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.6-alpine-3.9
+        context: variants/2.4.6-alpine-3.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-alpine-3-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-alpine-3-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-alpine-3-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-alpine-3-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.6-alpine-3.9 - Build and push (master)
+    - name: 2.4.6-alpine-3.9 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.6-alpine-3.9
+        context: variants/2.4.6-alpine-3.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-alpine-3-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-alpine-3-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-alpine-3-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-alpine-3-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.6-alpine-3.9 - Build and push (release)
+    - name: 2.4.6-alpine-3.9 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.6-alpine-3.9
+        context: variants/2.4.6-alpine-3.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-alpine-3-9.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-alpine-3-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-alpine-3-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-alpine-3-9.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-alpine-3-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-alpine-3-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-4-6-alpine-3-8
+      id: prep-2-4-6-alpine-3-8
       run: |
         set -e
 
@@ -703,7 +703,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.4.6-alpine-3.8"
+        VARIANT="2.4.6-alpine-3.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -713,45 +713,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.4.6-alpine-3.8 - Build (PRs)
+    - name: 2.4.6-alpine-3.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.6-alpine-3.8
+        context: variants/2.4.6-alpine-3.8
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-alpine-3-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-alpine-3-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-alpine-3-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-alpine-3-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.6-alpine-3.8 - Build and push (master)
+    - name: 2.4.6-alpine-3.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.6-alpine-3.8
+        context: variants/2.4.6-alpine-3.8
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-alpine-3-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-alpine-3-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-alpine-3-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-alpine-3-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.6-alpine-3.8 - Build and push (release)
+    - name: 2.4.6-alpine-3.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.6-alpine-3.8
+        context: variants/2.4.6-alpine-3.8
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-alpine-3-8.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-alpine-3-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-alpine-3-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-alpine-3-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-alpine-3-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-alpine-3-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -809,7 +809,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-4-4-alpine-3-7
+      id: prep-2-4-4-alpine-3-7
       run: |
         set -e
 
@@ -822,7 +822,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.4.4-alpine-3.7"
+        VARIANT="2.4.4-alpine-3.7"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -832,51 +832,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.4.4-alpine-3.7 - Build (PRs)
+    - name: 2.4.4-alpine-3.7 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.4-alpine-3.7
+        context: variants/2.4.4-alpine-3.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-4-alpine-3-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-4-alpine-3-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-4-alpine-3-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-4-alpine-3-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.4-alpine-3.7 - Build and push (master)
+    - name: 2.4.4-alpine-3.7 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.4-alpine-3.7
+        context: variants/2.4.4-alpine-3.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-4-alpine-3-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-4-alpine-3-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-4-alpine-3-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-4-alpine-3-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.4-alpine-3.7 - Build and push (release)
+    - name: 2.4.4-alpine-3.7 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.4-alpine-3.7
+        context: variants/2.4.4-alpine-3.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-4-alpine-3-7.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-4-alpine-3-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-4-alpine-3-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-4-alpine-3-7.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-4-alpine-3-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-4-alpine-3-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-4-4-alpine-3-6
+      id: prep-2-4-4-alpine-3-6
       run: |
         set -e
 
@@ -889,7 +889,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.4.4-alpine-3.6"
+        VARIANT="2.4.4-alpine-3.6"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -899,45 +899,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.4.4-alpine-3.6 - Build (PRs)
+    - name: 2.4.4-alpine-3.6 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.4-alpine-3.6
+        context: variants/2.4.4-alpine-3.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-4-alpine-3-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-4-alpine-3-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-4-alpine-3-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-4-alpine-3-6.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.4-alpine-3.6 - Build and push (master)
+    - name: 2.4.4-alpine-3.6 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.4-alpine-3.6
+        context: variants/2.4.4-alpine-3.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-4-alpine-3-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-4-alpine-3-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-4-alpine-3-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-4-alpine-3-6.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.4-alpine-3.6 - Build and push (release)
+    - name: 2.4.4-alpine-3.6 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.4-alpine-3.6
+        context: variants/2.4.4-alpine-3.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-4-alpine-3-6.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-4-alpine-3-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-4-alpine-3-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-4-alpine-3-6.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-4-alpine-3-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-4-alpine-3-6.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -995,7 +995,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-3-18-alpine-3-5
+      id: prep-2-3-18-alpine-3-5
       run: |
         set -e
 
@@ -1008,7 +1008,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.3.18-alpine-3.5"
+        VARIANT="2.3.18-alpine-3.5"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1018,51 +1018,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.3.18-alpine-3.5 - Build (PRs)
+    - name: 2.3.18-alpine-3.5 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.18-alpine-3.5
+        context: variants/2.3.18-alpine-3.5
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-5.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-5.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-5.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-5.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.3.18-alpine-3.5 - Build and push (master)
+    - name: 2.3.18-alpine-3.5 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.18-alpine-3.5
+        context: variants/2.3.18-alpine-3.5
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-5.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-5.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-5.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-5.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.3.18-alpine-3.5 - Build and push (release)
+    - name: 2.3.18-alpine-3.5 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.18-alpine-3.5
+        context: variants/2.3.18-alpine-3.5
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-5.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-5.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-5.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-5.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-5.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-5.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-3-18-alpine-3-4
+      id: prep-2-3-18-alpine-3-4
       run: |
         set -e
 
@@ -1075,7 +1075,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.3.18-alpine-3.4"
+        VARIANT="2.3.18-alpine-3.4"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1085,51 +1085,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.3.18-alpine-3.4 - Build (PRs)
+    - name: 2.3.18-alpine-3.4 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.18-alpine-3.4
+        context: variants/2.3.18-alpine-3.4
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-4.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-4.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-4.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-4.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.3.18-alpine-3.4 - Build and push (master)
+    - name: 2.3.18-alpine-3.4 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.18-alpine-3.4
+        context: variants/2.3.18-alpine-3.4
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-4.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-4.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-4.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-4.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.3.18-alpine-3.4 - Build and push (release)
+    - name: 2.3.18-alpine-3.4 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.18-alpine-3.4
+        context: variants/2.3.18-alpine-3.4
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-4.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-4.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-4.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-4.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-4.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-4.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-3-18-alpine-3-3
+      id: prep-2-3-18-alpine-3-3
       run: |
         set -e
 
@@ -1142,7 +1142,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.3.18-alpine-3.3"
+        VARIANT="2.3.18-alpine-3.3"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1152,45 +1152,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.3.18-alpine-3.3 - Build (PRs)
+    - name: 2.3.18-alpine-3.3 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.18-alpine-3.3
+        context: variants/2.3.18-alpine-3.3
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-3.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-3.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-3.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.3.18-alpine-3.3 - Build and push (master)
+    - name: 2.3.18-alpine-3.3 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.18-alpine-3.3
+        context: variants/2.3.18-alpine-3.3
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-3.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-3.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-3.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.3.18-alpine-3.3 - Build and push (release)
+    - name: 2.3.18-alpine-3.3 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.18-alpine-3.3
+        context: variants/2.3.18-alpine-3.3
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-3.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-3.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-18-alpine-3-3.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-3.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-18-alpine-3-3.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 

--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ Dockerized `openvpn`.
 
 | Tag | Dockerfile Build Context |
 |:-------:|:---------:|
-| `:v2.6.5-alpine-3.18`, `:latest` | [View](variants/v2.6.5-alpine-3.18) |
-| `:v2.5.8-alpine-3.17` | [View](variants/v2.5.8-alpine-3.17) |
-| `:v2.4.12-alpine-3.12` | [View](variants/v2.4.12-alpine-3.12) |
-| `:v2.4.11-alpine-3.11` | [View](variants/v2.4.11-alpine-3.11) |
-| `:v2.4.11-alpine-3.10` | [View](variants/v2.4.11-alpine-3.10) |
-| `:v2.4.6-alpine-3.9` | [View](variants/v2.4.6-alpine-3.9) |
-| `:v2.4.6-alpine-3.8` | [View](variants/v2.4.6-alpine-3.8) |
-| `:v2.4.4-alpine-3.7` | [View](variants/v2.4.4-alpine-3.7) |
-| `:v2.4.4-alpine-3.6` | [View](variants/v2.4.4-alpine-3.6) |
-| `:v2.3.18-alpine-3.5` | [View](variants/v2.3.18-alpine-3.5) |
-| `:v2.3.18-alpine-3.4` | [View](variants/v2.3.18-alpine-3.4) |
-| `:v2.3.18-alpine-3.3` | [View](variants/v2.3.18-alpine-3.3) |
+| `:2.6.5-alpine-3.18`, `:latest` | [View](variants/2.6.5-alpine-3.18) |
+| `:2.5.8-alpine-3.17` | [View](variants/2.5.8-alpine-3.17) |
+| `:2.4.12-alpine-3.12` | [View](variants/2.4.12-alpine-3.12) |
+| `:2.4.11-alpine-3.11` | [View](variants/2.4.11-alpine-3.11) |
+| `:2.4.11-alpine-3.10` | [View](variants/2.4.11-alpine-3.10) |
+| `:2.4.6-alpine-3.9` | [View](variants/2.4.6-alpine-3.9) |
+| `:2.4.6-alpine-3.8` | [View](variants/2.4.6-alpine-3.8) |
+| `:2.4.4-alpine-3.7` | [View](variants/2.4.4-alpine-3.7) |
+| `:2.4.4-alpine-3.6` | [View](variants/2.4.4-alpine-3.6) |
+| `:2.3.18-alpine-3.5` | [View](variants/2.3.18-alpine-3.5) |
+| `:2.3.18-alpine-3.4` | [View](variants/2.3.18-alpine-3.4) |
+| `:2.3.18-alpine-3.3` | [View](variants/2.3.18-alpine-3.3) |
 
 ## Usage
 
@@ -37,7 +37,7 @@ It is assumed that you have knowledge of configuring `openvpn`. If needed, refer
 To run the image, at the least you should mount a `/etc/openvpn/server.conf`, which may be a unified openvpn profile (see INLINE FILE SUPPORT section in the [openvpn manual](https://community.openvpn.net/openvpn/wiki/Openvpn24ManPage)).
 
 ```sh
-docker run --rm -it --cap-add NET_ADMIN -v /path/to/server.conf:/etc/openvpn/server.conf theohbrothers/docker-openvpn:v2.6.5-alpine-3.18
+docker run --rm -it --cap-add NET_ADMIN -v /path/to/server.conf:/etc/openvpn/server.conf theohbrothers/docker-openvpn:2.6.5-alpine-3.18
 ```
 
 ## Environment variables

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -132,9 +132,9 @@ $VARIANTS = @(
                     components = $subVariant['components']
                     job_group_key = $variant['package_version']
                 }
-                # Docker image tag. E.g. 'v2.3.0-alpine-3.6'
+                # Docker image tag. E.g. 'v2.6.5-alpine-3.18'
                 tag = @(
-                        "v$( $variant['package_version'] )" -replace '-r\d+', ''    # E.g. Strip out the '-r' in '2.3.0.0-r1'
+                        $variant['package_version']
                         $subVariant['components'] | ? { $_ }
                         $variant['distro']
                         $variant['distro_version']

--- a/variants/2.3.18-alpine-3.3/Dockerfile
+++ b/variants/2.3.18-alpine-3.3/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.3
+
+RUN apk add --no-cache openvpn>=2.3.18 iptables
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/2.3.18-alpine-3.3/docker-compose.yml
+++ b/variants/2.3.18-alpine-3.3/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '2.1'
+services:
+  openvpn-server:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
+      - NAT_MASQUERADE=1
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/server.conf:/etc/openvpn/server.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    ports:
+      - 1194:1194/udp
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped

--- a/variants/2.3.18-alpine-3.3/docker-entrypoint.sh
+++ b/variants/2.3.18-alpine-3.3/docker-entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+# Env vars
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
+OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
+NAT=${NAT:-1}
+NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
+CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    echo "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
+
+# If no args are passed, run the entrypoint. If a flag is passed, run openvpn directly. Else, run the passed command
+if [ "$#" -eq 0 ]; then
+    # Provision
+    echo "Provisioning tun device"
+    mkdir -p /dev/net
+    if [ ! -c /dev/net/tun ]; then
+        mknod /dev/net/tun c 10 200
+    fi
+    if [ -f "$CUSTOM_FIREWALL_SCRIPT" ]; then
+        echo "Executing custom firewall script: $CUSTOM_FIREWALL_SCRIPT"
+        . "$CUSTOM_FIREWALL_SCRIPT"
+    else
+        echo "Not executing custom firewall script $CUSTOM_FIREWALL_SCRIPT because it does not exist"
+    fi
+    if [ "$NAT" = 1 ]; then
+        echo "NAT is enabled"
+        echo "Provisioning NAT iptables rules"
+        echo "NAT_INTERFACE: $NAT_INTERFACE"
+        if [ "$NAT_MASQUERADE" = 1 ]; then
+            echo "NAT_MASQUERADE is enabled"
+            iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+            if [ -n "$OPENVPN_ROUTES" ]; then
+                echo "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+                for r in $OPENVPN_ROUTES; do
+                    iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+                done
+            else
+                echo "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+            fi
+        else
+            echo "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
+        fi
+    else
+        echo "NAT is disabled."
+        echo "Not adding NAT iptables rules"
+    fi
+
+    echo "Listing iptables rules:"
+    iptables -L -nv
+    echo "Listing iptables NAT rules:"
+    iptables -L -nv -t nat
+
+    # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
+    set openvpn --cd /etc/openvpn --config "$OPENVPN_CONFIG_FILE"
+    echo "openvpn command line: $@"
+    exec "$@"
+elif [ "$#" -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    echo "openvpn command line: $@"
+    exec openvpn "$@"
+fi
+
+exec "$@"

--- a/variants/2.3.18-alpine-3.3/openvpn/client.conf
+++ b/variants/2.3.18-alpine-3.3/openvpn/client.conf
@@ -1,0 +1,258 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/client.conf
+client
+dev tun
+proto udp
+remote openvpn-server 1194
+remote-random
+# Push all traffic into the tunnel
+;redirect-gateway def1 bypass-dhcp
+resolv-retry infinite
+nobind
+user nobody
+group nobody
+persist-key
+persist-tun
+remote-cert-tls server
+cipher AES-256-CBC
+auth SHA512
+comp-lzo
+verb 4
+key-direction 1
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:4e:3e:ee:0c:a0:be:17:77:36:7e:3e:48:bf:5a:f3
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=client-01
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:b3:ef:25:0f:86:77:8e:9f:a4:42:02:f0:19:0e:
+                    20:0e:93:5e:67:78:17:99:a9:cd:06:84:fe:c1:ed:
+                    5b:c9:96:d1:82:ef:5f:a5:95:d7:de:99:97:84:cc:
+                    a8:28:13:69:2f:41:7a:d4:f0:ac:a7:a3:10:8a:31:
+                    c6:aa:14:dd:d0:5d:15:51:2c:e9:5e:3e:fe:f0:1c:
+                    d7:62:07:f7:fb:01:93:22:8f:4b:72:77:76:8a:14:
+                    fe:26:52:59:c8:59:b0:01:b6:cb:7a:2d:ba:0d:35:
+                    a2:8c:42:97:18:54:45:58:f1:69:ff:3b:ce:fd:71:
+                    a5:13:42:82:ca:e2:25:43:61:d6:34:1f:f6:f3:36:
+                    7f:c9:7d:a4:e2:83:f1:8f:b7:2d:cd:7f:cf:1a:90:
+                    a4:86:ce:c0:6b:36:b3:9e:90:d0:60:5c:ec:ac:70:
+                    f7:32:16:59:20:1f:27:a5:3c:00:a0:9b:63:30:41:
+                    a5:d3:63:37:9d:10:f7:f6:53:45:54:57:70:7e:06:
+                    a6:01:32:38:2c:2d:d1:11:4c:3f:57:25:5a:2c:2c:
+                    06:a0:20:bb:c0:95:fd:44:a8:0d:3a:b0:c9:a3:b2:
+                    77:ce:f7:f0:f5:c8:1c:a7:74:ba:b9:83:0b:3c:56:
+                    6f:18:cb:df:39:77:3a:69:18:57:be:48:7e:ab:2a:
+                    21:2d:b0:eb:4c:26:ae:93:f2:d9:0d:29:01:b8:2c:
+                    0b:5a:ec:8a:c0:fd:5d:1c:a7:6f:31:29:5d:5c:35:
+                    cd:0e:e0:97:86:07:af:5e:69:8e:e7:e1:f0:78:21:
+                    f3:15:c6:35:cd:e6:4b:65:d5:17:0b:87:6e:ea:39:
+                    44:96:ab:bc:fc:ee:27:85:fe:10:c4:77:96:25:cd:
+                    9a:66:ee:e4:36:fb:f0:c8:90:62:de:6d:f6:8c:19:
+                    76:c6:6d:c3:9c:a4:9f:80:ec:39:79:ba:32:36:b2:
+                    7d:93:3c:dc:58:c5:13:34:35:8a:7e:cb:cc:f0:9a:
+                    bb:39:dd:ca:bc:cf:c7:7a:8f:9b:60:f1:a8:e6:e4:
+                    41:62:82:cd:cc:d2:81:06:c1:5b:82:0c:49:88:e6:
+                    bd:39:b2:06:82:a0:fb:55:ba:fd:de:57:2f:40:84:
+                    07:b8:38:9a:49:6e:38:49:c0:b9:26:f7:7e:a9:9a:
+                    18:b3:27:b9:d9:b3:fb:7f:6d:9e:68:58:94:f7:b1:
+                    21:b5:ee:59:b0:7f:fc:0f:ab:00:c2:8e:94:34:09:
+                    c3:45:dd:4c:79:03:b8:bf:ce:55:8f:6e:6d:c9:ff:
+                    4c:5b:da:fb:eb:70:bd:c9:37:68:6e:03:e0:db:2f:
+                    6e:db:6c:d4:f0:1f:01:43:42:6e:f6:31:4b:8d:fb:
+                    21:1e:77
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                23:46:34:1C:74:3B:D8:21:40:4D:81:B3:58:9F:57:CB:0C:5E:90:FB
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+    Signature Algorithm: sha256WithRSAEncryption
+         3c:80:ef:a8:a1:94:bc:12:33:6c:19:2e:44:44:6c:20:8e:69:
+         f6:b8:21:ad:4b:f7:14:d6:bf:c3:8d:b0:87:d1:e2:55:df:c0:
+         fd:03:31:82:8a:82:dd:68:3d:61:1f:c4:89:eb:e6:07:b0:89:
+         1d:19:8b:ee:57:9f:87:d8:a2:d8:fe:84:ad:f1:18:9c:b5:93:
+         a1:17:48:41:1e:f7:12:1e:50:46:b7:57:93:6e:d5:0f:d5:84:
+         a8:8e:74:4f:ab:8a:ae:40:64:8a:a8:57:32:75:b6:82:20:10:
+         be:ab:70:0c:96:c7:30:f4:69:c7:c9:24:db:3a:bc:40:eb:ac:
+         ee:04:f3:58:4a:09:6e:42:01:b4:a5:77:e5:2b:01:05:c1:5c:
+         08:59:0b:e3:a9:7a:b4:3e:f9:41:8d:2b:e6:8e:40:27:07:07:
+         0d:b0:03:ba:c9:d2:cd:dd:3c:9a:7e:20:66:bb:7f:4f:9d:fc:
+         37:16:88:84:a1:26:6a:91:43:d1:47:82:cb:e1:84:d4:03:93:
+         ec:8d:14:ce:2c:c8:fc:96:f8:28:d5:cb:89:c8:84:ee:8a:54:
+         8e:3c:12:86:10:73:78:5c:b8:a5:7d:99:94:b1:e1:f9:18:ed:
+         4b:2f:ae:8d:d4:9b:bc:20:21:d3:13:ed:07:15:70:dc:d1:1f:
+         58:22:fc:0e:5a:49:4e:6f:c1:99:9d:de:71:4e:62:7d:ad:d3:
+         2e:c3:ca:3f:db:cf:f3:46:aa:95:1f:99:1c:81:f8:15:5a:a1:
+         30:f7:7b:4a:e1:8a:fa:8b:a4:92:6d:11:e3:4c:f5:2b:b9:a3:
+         6d:a4:07:93:cb:28:f7:06:c1:e8:1b:1e:c5:aa:76:51:7e:1b:
+         a7:fe:db:9b:d4:23:d1:2a:16:52:ed:d1:2c:55:2b:cd:db:73:
+         fa:20:1a:18:47:af:90:50:0c:fe:1b:0d:f6:06:ec:33:1f:8e:
+         6f:f2:9a:d0:49:88:cb:a0:8c:8a:60:54:8e:d0:c1:59:ad:e6:
+         6e:6a:3e:e4:3b:b4:1b:01:8e:81:a4:f2:21:94:d1:a7:5e:e8:
+         1a:14:af:f1:46:5d:6a:ad:9d:06:02:84:58:96:b2:e6:f8:02:
+         5f:ce:ed:87:54:b5:f9:b6:62:97:51:b2:88:05:49:de:fd:56:
+         d1:67:e5:59:78:31:82:36:17:ce:07:62:81:5c:19:82:48:22:
+         88:15:ea:d9:fc:1e:c3:ee:05:a5:ec:e9:ca:69:b5:2a:7e:79:
+         ed:aa:6e:3f:b5:45:75:0b:d4:27:e4:4c:88:04:e0:06:36:5e:
+         41:37:b0:f5:44:80:58:86:dc:c1:be:82:62:fe:a8:2c:6c:ca:
+         6a:f8:dd:fd:85:df:5a:41
+-----BEGIN CERTIFICATE-----
+MIIFUTCCAzmgAwIBAgIQDU4+7gygvhd3Nn4+SL9a8zANBgkqhkiG9w0BAQsFADAT
+MREwDwYDVQQDDAhDaGFuZ2VNZTAeFw0yMzA2MzAxMTQ1MTJaFw0yNTEwMDIxMTQ1
+MTJaMBQxEjAQBgNVBAMMCWNsaWVudC0wMTCCAiIwDQYJKoZIhvcNAQEBBQADggIP
+ADCCAgoCggIBALPvJQ+Gd46fpEIC8BkOIA6TXmd4F5mpzQaE/sHtW8mW0YLvX6WV
+196Zl4TMqCgTaS9BetTwrKejEIoxxqoU3dBdFVEs6V4+/vAc12IH9/sBkyKPS3J3
+dooU/iZSWchZsAG2y3otug01ooxClxhURVjxaf87zv1xpRNCgsriJUNh1jQf9vM2
+f8l9pOKD8Y+3Lc1/zxqQpIbOwGs2s56Q0GBc7Kxw9zIWWSAfJ6U8AKCbYzBBpdNj
+N50Q9/ZTRVRXcH4GpgEyOCwt0RFMP1clWiwsBqAgu8CV/USoDTqwyaOyd8738PXI
+HKd0urmDCzxWbxjL3zl3OmkYV75IfqsqIS2w60wmrpPy2Q0pAbgsC1rsisD9XRyn
+bzEpXVw1zQ7gl4YHr15pjufh8Hgh8xXGNc3mS2XVFwuHbuo5RJarvPzuJ4X+EMR3
+liXNmmbu5Db78MiQYt5t9owZdsZtw5ykn4DsOXm6MjayfZM83FjFEzQ1in7LzPCa
+uzndyrzPx3qPm2DxqObkQWKCzczSgQbBW4IMSYjmvTmyBoKg+1W6/d5XL0CEB7g4
+mkluOEnAuSb3fqmaGLMnudmz+39tnmhYlPexIbXuWbB//A+rAMKOlDQJw0XdTHkD
+uL/OVY9ubcn/TFva++twvck3aG4D4Nsvbtts1PAfAUNCbvYxS437IR53AgMBAAGj
+gZ8wgZwwCQYDVR0TBAIwADAdBgNVHQ4EFgQUI0Y0HHQ72CFATYGzWJ9XywxekPsw
+TgYDVR0jBEcwRYAUmBuw7bvaYZi1OnrIxE4ycKX4qQehF6QVMBMxETAPBgNVBAMM
+CENoYW5nZU1lghQRFLv/ZzUIweAY3+3bxHLwDm1FLDATBgNVHSUEDDAKBggrBgEF
+BQcDAjALBgNVHQ8EBAMCB4AwDQYJKoZIhvcNAQELBQADggIBADyA76ihlLwSM2wZ
+LkREbCCOafa4Ia1L9xTWv8ONsIfR4lXfwP0DMYKKgt1oPWEfxInr5gewiR0Zi+5X
+n4fYotj+hK3xGJy1k6EXSEEe9xIeUEa3V5Nu1Q/VhKiOdE+riq5AZIqoVzJ1toIg
+EL6rcAyWxzD0acfJJNs6vEDrrO4E81hKCW5CAbSld+UrAQXBXAhZC+OperQ++UGN
+K+aOQCcHBw2wA7rJ0s3dPJp+IGa7f0+d/DcWiIShJmqRQ9FHgsvhhNQDk+yNFM4s
+yPyW+CjVy4nIhO6KVI48EoYQc3hcuKV9mZSx4fkY7Usvro3Um7wgIdMT7QcVcNzR
+H1gi/A5aSU5vwZmd3nFOYn2t0y7Dyj/bz/NGqpUfmRyB+BVaoTD3e0rhivqLpJJt
+EeNM9Su5o22kB5PLKPcGwegbHsWqdlF+G6f+25vUI9EqFlLt0SxVK83bc/ogGhhH
+r5BQDP4bDfYG7DMfjm/ymtBJiMugjIpgVI7QwVmt5m5qPuQ7tBsBjoGk8iGU0ade
+6BoUr/FGXWqtnQYChFiWsub4Al/O7YdUtfm2YpdRsogFSd79VtFn5Vl4MYI2F84H
+YoFcGYJIIogV6tn8HsPuBaXs6cpptSp+ee2qbj+1RXUL1CfkTIgE4AY2XkE3sPVE
+gFiG3MG+gmL+qCxsymr43f2F31pB
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQCz7yUPhneOn6RC
+AvAZDiAOk15neBeZqc0GhP7B7VvJltGC71+lldfemZeEzKgoE2kvQXrU8KynoxCK
+McaqFN3QXRVRLOlePv7wHNdiB/f7AZMij0tyd3aKFP4mUlnIWbABtst6LboNNaKM
+QpcYVEVY8Wn/O879caUTQoLK4iVDYdY0H/bzNn/JfaTig/GPty3Nf88akKSGzsBr
+NrOekNBgXOyscPcyFlkgHyelPACgm2MwQaXTYzedEPf2U0VUV3B+BqYBMjgsLdER
+TD9XJVosLAagILvAlf1EqA06sMmjsnfO9/D1yByndLq5gws8Vm8Yy985dzppGFe+
+SH6rKiEtsOtMJq6T8tkNKQG4LAta7IrA/V0cp28xKV1cNc0O4JeGB69eaY7n4fB4
+IfMVxjXN5ktl1RcLh27qOUSWq7z87ieF/hDEd5YlzZpm7uQ2+/DIkGLebfaMGXbG
+bcOcpJ+A7Dl5ujI2sn2TPNxYxRM0NYp+y8zwmrs53cq8z8d6j5tg8ajm5EFigs3M
+0oEGwVuCDEmI5r05sgaCoPtVuv3eVy9AhAe4OJpJbjhJwLkm936pmhizJ7nZs/t/
+bZ5oWJT3sSG17lmwf/wPqwDCjpQ0CcNF3Ux5A7i/zlWPbm3J/0xb2vvrcL3JN2hu
+A+DbL27bbNTwHwFDQm72MUuN+yEedwIDAQABAoICAAuYKlwwvv16vfve8pe6uEgY
+KOoj6+lj7qkv4raeU97OkBuOzyv9VtaqMQBGq8NBVPLNlluoUofO0x8EjBejlpN5
+nAkKCtOe3ZCdWyee+dS7yj5c23C5z/Kf3ayce9qUJOpHXB84WRfGz/2XwOK5c2qC
+y+C9et4L96YhEAqAvgP0hvf+40vSxDM4nGpYNDWdiR8H0FGW5nMlWXLPKI3cKQE8
+m6eU8+jPVdjjCQv1rNisipyubkAL0aaWVFQUE5CWvdHxHbtQABygqyshLaew6XmV
+MKwaz95eC97jsU6J28RnmJ7GjUlZJreHpwyTLCMsMqZ3ZJ/wVdw1zFmflEH1SgPq
+/JNd0OONKm8x7nORX9dHEn33Imfyg2jI6tzVx1oAmMWMb9hJ0XjkIyzjfHTPi5KW
+pM3pTUUn6ee4P1T4ReBlatiw2TFgAd18/9gSIaSlENEjslJGQ6/Ndt9O7UNHgwth
+ZNtPovjNLqUobHGXlmwg3haeBshn9iPcjdksAjgtjEyowzq7IpiSxQezXNcMezGM
+Y9UL5Qc/yjQ3t+Vu94Jmnu0TT3lHGWa3zSgI6L+UdBiIsLF6P5YQVloYOYWE3q/n
+HTaORoZlsRKfMIUHmhrZ1keJ4VGqLruSpQHobh3Cfb/xzgOEB3nSwhIK3l2FhSiR
+N9jb0r7kMElO+xlm7NChAoIBAQDllnlfyWnTBGog8+T9eJiODuBfdozy2vCZO8nc
+vp11NC7fLh5NXR16Ju6I+dcXDhPdoOG8H/DScjer82kEINrY7Wb4swNd01cLCg+/
+xVNe9iiLl4Q4m/QOI6ZOUbOfJjH9R8J4Bh/FzR1MXtVktgtsd6JB3zv6V246zDjy
+eMnOImwoj6TH/3hI/g2s5i3GoaC7CK+XjpdfZbVAX5+mnpZxBbOqXt7an1IzYHhx
+hQO8uo/9b2IDxMrWWn80mGj9Fw5AdK1Ef3eMtbyG6iOIR92UEo9ZwlZ9Tang58Sa
+7IFHZko/HcCrS92Hl9YcnYmjG0GDeFl4des+IcVz0AHDhe6RAoIBAQDIolXgCYO3
+zo2MtoBTCr+GcluT4DD16ALz7wd8/jXFqmD3UWCAeaS5IsTno1PmuIpvB7dvwz8B
+6SOpE//J/bECDmhE18UHYOAqkXzzuuEGMCP1TuaCWBq7kWV8GVTRcSGQDxLyf/Yu
+IdxiPQMaCxi0Ffv+aq27Nii1IyV8tyDL3skyGZeQJNW2xjNkngkXsB5Tp7H7tA0G
+lSmld1Rtq2XWcRnHQh9ZVP+FxwkjBkdoX0oAASVQwHsy9Q4hZ5ykxPkIGULj3Hw5
+zvG1RAM5B4GQegK0OfYuX5Ullrz6a/6p/FnGLvRkZGlHML/bHTmrr8ywSvF63Gkd
+oU0nqjPFQ1CHAoIBACoFR4PDno3TwgTz/tZxqyJdEK4ISbXtYpn5OnIfpTwdZ/LL
+QxqPz2RbGc+SQs7icbpfxtEi23X5F71uGKt7w/JuSSl9wkD6/HR1y/oiiKbZ0QPz
+oGyoBpxL5BVzmLepSv77kllbbZdLenBO7ym2tBKPNvBthlHEjNVQKaAfgXgsDrXB
+zLwaQw7BCQm7O2eej4eMCG9p1sTMHceBePwLDKf1DjRBlvJWtLnYj1LfsJZrYw1U
+xJDCBQoEmEGtH5IrFR2w/UGLPvtPDAl5czVvSdvfJcOc8S2P+GbEpNRiMys5Sp+Q
+t4HiqdI2dSbZoqZqx6vjbCTDGGJP1g7jZF8/9TECggEAXOXVj2O4an4oSnQiXNEI
+N29x+bl/0gy4eUw/El/+c+Tc+wbiAPrSC6sOsxaL/bOK3bgb9pLX9MGHcn1BHbzq
+ncIgA2hI4Y64nN06lvv7v0rBC4+Z6dZzok/DRr/P5x5T5Qklw8T+LwQcsBwB+KgU
+qyXWxUmN4bZFCQIaFHISrHMeg6UX6XU0w2loWHlYSnCQyjlGjv4iXd7pJqVnIVSQ
+VceOoRV7wHg7zCyJjX8Vxzz/3ZqqNYa6RLD09wCrphtSF67iqvDnUDkC7+Rq/Zf9
+JPFpmRuRYo19WKdAH0+r3fdrdfk9zdI0cPMgkosordc7lpFM2I9/2GlceTY0vGzb
+twKCAQEArUbkiwUZFjdjAbKS2m0uPJyytB8bZ335szcoMUV665hzU9EJPcWeVY0L
+1FSRu/cig+ZCmpUEc/4JhJVKLEEXgC3BgfHGNHi5PIuvssMT/fJJ9InQe8n4Zq0Q
+eZbrfAewrdH3bTpEf6AxIsrMioLsUQSV12iRQ7olsEP9t5HqRKqwhAnqp+q33XT3
+L++8IcaaEQ3S/sBb23pY+VSWQfKGFVQES+P7yKeNHjBNQpJTPOdM9iLtvriUmNdO
+Gy5HOpLgd10DzXBOI7CgqzFm69Bqk+WFZXGVd9T/Ku69B8XfshoRChGbgHbbEG70
+0xT4AQEuygYVBbUrIerZFpDD+Tw7ww==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.3.18-alpine-3.3/openvpn/firewall.sh
+++ b/variants/2.3.18-alpine-3.3/openvpn/firewall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# This iptables script to controlling traffic in the openvpn tunnel.
+# In this example, clients can only perform DNS, HTTP and HTTPS requests to the world.
+
+# Drop everything by default from tunnel to world
+iptables -P FORWARD DROP
+# Allow DNS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p udp -m udp --dport 53 -m conntrack --ctstate NEW -j ACCEPT
+# Allow HTTP and HTTPS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p tcp -m tcp -m conntrack --ctstate NEW -m multiport --dports 80,443 -j ACCEPT

--- a/variants/2.3.18-alpine-3.3/openvpn/server.conf
+++ b/variants/2.3.18-alpine-3.3/openvpn/server.conf
@@ -1,0 +1,280 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/server.conf
+port 1194
+proto udp
+dev tun
+server 10.8.0.0 255.255.255.0
+ifconfig-pool-persist tun-ipp.txt
+;client-config-dir ccd
+keepalive 10 120
+comp-lzo no
+max-clients 5
+user nobody
+group nogroup
+persist-key
+persist-tun
+status tun.status
+status-version 3
+;log-append server.log
+verb 4
+mute 20
+;duplicate-cn
+tls-version-min 1.2
+cipher AES-256-CBC
+auth SHA512
+key-direction 0
+;crl-verify crl.pem
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            97:80:c6:6b:b5:84:81:b3:2b:f6:56:55:da:67:4d:c8
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=server
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:be:f7:ee:15:bc:b6:e1:04:28:3e:38:6a:61:dd:
+                    ee:fa:61:85:9a:a7:be:44:22:52:b4:cf:7a:86:0e:
+                    21:ae:1e:2b:61:66:17:1f:54:dc:e9:75:27:55:24:
+                    39:fc:ee:92:d1:da:de:e2:5f:01:50:b6:ae:52:1a:
+                    79:6b:8d:56:0d:83:f6:d4:19:50:48:bc:cb:d8:69:
+                    c8:79:d4:ba:82:05:db:aa:58:12:4b:34:1b:15:d1:
+                    28:2d:b7:08:4e:a0:64:fb:c6:b4:e2:8b:61:68:4e:
+                    72:72:cc:da:a2:d8:cb:f5:6a:5d:13:b6:98:d3:0c:
+                    a3:05:7a:21:e3:f9:fb:de:89:be:37:ac:ce:4c:2e:
+                    95:98:9e:48:3c:04:97:cd:a3:36:92:15:12:a4:bf:
+                    46:ea:95:37:0c:6f:09:e1:51:f5:4e:13:9f:f5:68:
+                    65:0e:24:38:62:04:f8:f9:0c:06:72:c9:03:ed:5d:
+                    6f:40:3b:62:ea:a2:79:01:79:d0:58:aa:2c:7f:89:
+                    14:bc:3e:86:c0:5e:58:ac:58:c0:97:fe:65:57:46:
+                    bf:01:cc:d4:d7:64:d8:21:15:02:6b:6a:38:24:bb:
+                    2b:45:c7:79:23:7a:7f:0c:6b:25:d3:ce:e1:3f:e8:
+                    68:6c:31:7a:df:88:49:6d:a3:7e:22:24:08:3d:e1:
+                    6c:87:dd:34:77:d2:a5:eb:f7:e6:74:b9:e2:5f:e4:
+                    ad:49:e1:c0:b4:8f:d9:b5:ac:2d:7b:ba:22:64:8e:
+                    b7:c1:11:11:f1:e1:1f:b9:3e:29:b1:61:9b:8a:1c:
+                    2e:d4:e4:e6:10:5a:5d:e1:f9:1e:54:7b:13:79:dd:
+                    d9:ad:8b:23:c4:8d:a5:8b:f5:17:eb:99:96:5d:c6:
+                    8d:b4:af:8b:4c:2f:08:4d:37:c3:bf:6d:68:99:c4:
+                    f7:47:cc:5d:44:e7:6e:f2:64:b3:7d:bb:9b:c7:e1:
+                    27:cf:73:8d:b2:e2:88:19:6c:bb:6e:cd:4a:0a:79:
+                    a8:7b:9d:c3:b0:59:93:51:20:a1:d8:a2:0f:e5:62:
+                    76:17:b3:bb:aa:bc:3a:73:e7:f6:57:91:6a:cb:d3:
+                    7e:91:38:5e:88:57:e3:d8:3e:31:cd:dc:69:9a:74:
+                    bb:6e:62:c2:ab:5b:8c:f5:80:ff:b4:98:a2:87:15:
+                    72:38:77:76:dc:e2:d1:ac:2f:66:67:ae:c4:33:a8:
+                    86:94:af:41:b1:99:0d:5d:68:df:9a:ec:86:0f:0a:
+                    c9:67:fa:a1:7c:29:47:d3:f1:c1:3d:8a:d1:a4:12:
+                    a6:70:16:37:80:4f:d9:79:61:45:1c:07:77:68:60:
+                    4e:10:ec:94:dd:03:95:b1:37:cc:88:3d:60:cc:32:
+                    37:be:a5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                4A:91:C2:3E:A1:E9:04:C9:C0:9A:8B:CE:D4:37:4D:96:0E:74:FE:90
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication
+            X509v3 Key Usage:
+                Digital Signature, Key Encipherment
+            X509v3 Subject Alternative Name:
+                DNS:server
+    Signature Algorithm: sha256WithRSAEncryption
+         72:b4:75:02:f7:7b:e9:07:c6:79:1b:bb:11:e4:73:4a:b4:76:
+         1c:03:b9:58:8c:0a:80:f0:c6:8c:cc:2a:a7:c7:8c:57:a8:6e:
+         52:19:f0:b5:7c:0f:06:ab:2f:04:0e:99:32:b9:2c:b6:42:f0:
+         f5:5b:97:32:ce:bb:0c:ee:9f:b0:0b:bc:0b:c0:43:1d:7d:04:
+         b4:a1:cf:a0:aa:fe:f1:cc:b4:31:b3:bb:78:ed:0e:60:8d:37:
+         ea:48:a7:b4:2d:6d:64:6e:97:15:aa:e4:9b:b4:68:79:c8:3b:
+         ba:91:0b:db:cd:04:a3:aa:e4:69:59:06:ec:50:68:6d:0d:a6:
+         38:32:55:76:09:10:00:da:ac:a8:9e:ad:ad:95:8f:01:88:c9:
+         40:af:9a:5c:2d:17:34:81:6b:26:65:8a:e5:2a:15:79:13:2d:
+         ae:d8:03:16:6b:e9:b6:cd:f3:cb:d5:4d:5f:40:76:7a:99:99:
+         d5:2f:e8:a1:59:88:01:6b:a1:36:c0:53:dc:46:07:fd:ab:ab:
+         2a:5b:d3:d5:4c:84:c2:fb:48:16:80:80:01:f6:37:80:3a:54:
+         81:11:24:86:a6:a2:9a:73:06:5f:ca:24:8c:20:3a:40:6e:95:
+         8e:44:46:ef:60:bc:9d:11:ad:71:af:61:85:a6:e2:b4:49:c7:
+         fa:bb:ef:b5:c9:02:d2:a2:a5:3b:f6:46:03:dc:58:9f:ff:dc:
+         23:6b:b5:02:4c:1a:1a:80:99:6d:1a:fd:24:fc:32:83:f7:de:
+         fd:2b:b2:45:b7:3b:89:3c:49:0c:3d:0b:05:67:a5:95:00:3d:
+         cd:a7:0a:3b:b5:cd:02:10:09:de:ff:6c:6b:8b:aa:9d:e6:e9:
+         07:83:e2:dd:de:6d:bc:9e:fd:19:77:30:5d:67:12:c2:33:40:
+         0f:13:69:98:02:ef:05:b2:ad:ef:fb:73:15:57:70:46:83:32:
+         a9:05:4d:31:06:3d:44:93:88:69:de:9a:67:b4:6b:b7:0d:6b:
+         69:24:8b:62:52:f7:85:66:8f:84:2d:c0:a7:ff:33:37:7c:f3:
+         d1:1f:8c:b6:16:a3:98:db:6e:aa:e5:eb:d8:ed:06:31:19:ba:
+         01:f1:e6:3e:bc:78:ec:6e:b4:af:6c:8a:49:0f:ff:5a:f0:00:
+         88:d8:66:af:d6:49:31:b5:54:ce:be:07:59:46:bb:67:73:4b:
+         b8:ec:be:16:04:ed:fe:75:57:21:d6:d5:7b:cc:d0:7c:bd:91:
+         d3:6e:61:72:04:30:24:45:0a:0d:16:b6:35:94:49:02:14:8d:
+         2d:1d:71:42:13:9a:02:1e:3c:31:05:b4:76:5b:dd:ff:bb:db:
+         f4:31:b7:47:bb:54:f8:27
+-----BEGIN CERTIFICATE-----
+MIIFYjCCA0qgAwIBAgIRAJeAxmu1hIGzK/ZWVdpnTcgwDQYJKoZIhvcNAQELBQAw
+EzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMjUxMDAyMTE0
+NTEyWjARMQ8wDQYDVQQDDAZzZXJ2ZXIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+ggIKAoICAQC+9+4VvLbhBCg+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzp
+dSdVJDn87pLR2t7iXwFQtq5SGnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV
+0SgttwhOoGT7xrTii2FoTnJyzNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWY
+nkg8BJfNozaSFRKkv0bqlTcMbwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2Lq
+onkBedBYqix/iRS8PobAXlisWMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8M
+ayXTzuE/6GhsMXrfiElto34iJAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17
+uiJkjrfBERHx4R+5PimxYZuKHC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZd
+xo20r4tMLwhNN8O/bWiZxPdHzF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7
+ncOwWZNRIKHYog/lYnYXs7uqvDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKr
+W4z1gP+0mKKHFXI4d3bc4tGsL2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT
+8cE9itGkEqZwFjeAT9l5YUUcB3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABo4Gy
+MIGvMAkGA1UdEwQCMAAwHQYDVR0OBBYEFEqRwj6h6QTJwJqLztQ3TZYOdP6QME4G
+A1UdIwRHMEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhD
+aGFuZ2VNZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwEwYDVR0lBAwwCgYIKwYBBQUH
+AwEwCwYDVR0PBAQDAgWgMBEGA1UdEQQKMAiCBnNlcnZlcjANBgkqhkiG9w0BAQsF
+AAOCAgEAcrR1Avd76QfGeRu7EeRzSrR2HAO5WIwKgPDGjMwqp8eMV6huUhnwtXwP
+BqsvBA6ZMrkstkLw9VuXMs67DO6fsAu8C8BDHX0EtKHPoKr+8cy0MbO7eO0OYI03
+6kintC1tZG6XFarkm7Roecg7upEL280Eo6rkaVkG7FBobQ2mODJVdgkQANqsqJ6t
+rZWPAYjJQK+aXC0XNIFrJmWK5SoVeRMtrtgDFmvpts3zy9VNX0B2epmZ1S/ooVmI
+AWuhNsBT3EYH/aurKlvT1UyEwvtIFoCAAfY3gDpUgREkhqaimnMGX8okjCA6QG6V
+jkRG72C8nRGtca9hhabitEnH+rvvtckC0qKlO/ZGA9xYn//cI2u1AkwaGoCZbRr9
+JPwyg/fe/SuyRbc7iTxJDD0LBWellQA9zacKO7XNAhAJ3v9sa4uqnebpB4Pi3d5t
+vJ79GXcwXWcSwjNADxNpmALvBbKt7/tzFVdwRoMyqQVNMQY9RJOIad6aZ7Rrtw1r
+aSSLYlL3hWaPhC3Ap/8zN3zz0R+MthajmNtuquXr2O0GMRm6AfHmPrx47G60r2yK
+SQ//WvAAiNhmr9ZJMbVUzr4HWUa7Z3NLuOy+FgTt/nVXIdbVe8zQfL2R025hcgQw
+JEUKDRa2NZRJAhSNLR1xQhOaAh48MQW0dlvd/7vb9DG3R7tU+Cc=
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQC+9+4VvLbhBCg+
+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzpdSdVJDn87pLR2t7iXwFQtq5S
+GnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV0SgttwhOoGT7xrTii2FoTnJy
+zNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWYnkg8BJfNozaSFRKkv0bqlTcM
+bwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2LqonkBedBYqix/iRS8PobAXlis
+WMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8MayXTzuE/6GhsMXrfiElto34i
+JAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17uiJkjrfBERHx4R+5PimxYZuK
+HC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZdxo20r4tMLwhNN8O/bWiZxPdH
+zF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7ncOwWZNRIKHYog/lYnYXs7uq
+vDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKrW4z1gP+0mKKHFXI4d3bc4tGs
+L2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT8cE9itGkEqZwFjeAT9l5YUUc
+B3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABAoICAAnfT1OYWevwBxSQXg+JJZ2U
+BRAls9RZ4eSvBSqA+ITD0oJKgM+B15nKEKp6IPVOcBChO/x/5NWDXCeqbrR8rgIs
+3EnCtT/NYsxhS5fgw3ONUfnQa8Gvg+bw1R7n42oNKKtLbnZ3tiVqSMhehr78bi7V
+vNIUEnp2oMbbtXzPo5GxlT/TkyalEd698AYKRr6+vUd4B2q06Lmf1SSzaNNZJVFP
++mj5aJ/+h1up3iUh1gOBGM7gkavEZiyzEYZeAcNTqNE/CO9iXBz9w5/FRs+UuzBz
+29P//tDTyciMCX/8EcL0WhxVX5HR91dxApecjlB7d0qAlFWR+hnM5exl6HcqfC3C
++Uhi5IC+gZjD2KCcHDr9e5WqQ6cu8TeMnoyuHInIV9kUL3Bn1ArOU1dmGS78soeE
+GpqGCRc9Imh8jxs1AVyj9wGzpfuRS8OBpfR5MIlcFwSlZO/6dnJSaF2BH1jnKgBG
+Xn9MvjfHTU/EhLTteXrAJlqQr4e/uAK5QCESFNXLvC0r3qord6b9Y0zHR63SpESJ
+WVUIF9L2fIh0Z4CutPegcbEyWLaaAT4njyR4uCI78g77kK+PGi2NM65Mk+wKt975
+m3Qh4/cNv1ews4h+RflayWC9kiiRVzDHJGTy63k5gdplqrW2rb8gK3ZQaT2gQp9u
+gjKIIFGyi+EIDSukHNdRAoIBAQDuGvE9k1lSvoPgSusogMk7PWTiZbn8MwlEFueM
+ZJk9k8dMSkqF1k5BXG9lHcWuFl2invgTiFJIF7ML0GDsFJR+CzCDsanSGdjyKfGM
+HzHAc7UPAJYBXPX1rxTAhGSirKjArcqYUX3ZGGaTo1yZrsbbarInUhWWNKFBdaQ+
++L3oClGt3GZx7hdxapI/3gnkLvG/C5hWWetLONZAxY6jwJJSA/p2Fx93SlWOtrmT
+KRbM/p8m6sHtsXcBnYTueqWYpJ2mnBIB+Svf5acqQ2Xf8kAIw4Vw9u7a15OlIDGF
+ouWhtSkL4s0YfZjlXswOPZDlF3eT2ilf+OIjv5kEcLdDKOojAoIBAQDNUhfys2TH
+b1NFsIH6X1jtWHUEGOYIM/y/75Vw2pGLb40cMxVPtzsNCvz8id/sCuvx6yUWlBlN
+wjpa+7dOA+FgoXwv1iVsQm1zQlrt2VKaEy29C0tRkSwOjNC0bz1409wzYNnh5Bdx
+KJDvSz9zlefAryJGTSgGOothOjnguzoEJ6DxfkxNyWbxceBgN8JljDhc9dcybKdD
+Uxy2GflXhZvZfCtTbYfWoIV+dTYyZt2QE4PEPXrJHGUFE9ncGynbzAn1Cc/zGBeT
+zFNoYOCWNr7ueRNHQYMRZ1N3dYRdZ9th5mdqqa1eY5lP4PyQYZV6lwmyEfitXwNz
+vhS0sO+pNAyXAoIBAB9OiZOoESGRDTPrhdnwfQT+AIrIB1lCuKAsRsut2nw/NwAv
+8HaChA2SAs+Px5MpO6yLLGEdFnyGKTOPdX71AcVE4V8feA24+k50916OJ3N/gzny
+wMZzG5/vIlJh1f2RqCqVb0LxzBNEYxBcdWt7kIf/EmebIl16lA1QU4U4HXgqCy1K
+AmpOfOSbt5kQL8rB5WVSN/h6oDZmxb0EfMnJIzQHc+IdDjUYIAHAwsu3pljTzcdH
+LLJ9GAGtXXIhzC4yzsu+T5vU0FEDGCS1ceqtJoBAfQYqYaOCntYiUoCYt4q4kCoQ
+6xiiQv09pqTksW191WoqUDBfQBSlN5Be5am98nMCggEAIzEb+7R15J0XN82uKZzo
+IB5WSDKAUw2eF8PX6HT+F1kyZY/36ibszyp//EUhhVLF6Dw2qi0OPT66Q9f7LjsK
+CUcEgyqAVZL5MZVBAp2KQ/BfmZRy/3MTixbluteKQMiHaKMEFWzD+9hJJ0rNgGFE
+TMl35XbaEl88fpi9TOCqbAXi1yGfsIGBzIaJP9Su1Dr5ei2FChaHgMmhFTFUhITZ
+FqjqwCz46HexCeDLPk5VUZmWry8eeZQNWJZzc/+P6CWL210oMHGDsQiHj09zjyup
+BDTqcf8vmO8N5l7VJjFj797PAQA+P/xwTbmxcInZVh7HQadE6WpsrAz7fZEKMwVB
+1wKCAQEA3oqXI9bGGoXFjydUiNMZbuHdIDQCa9t7iDb+J+NAiA7GI8W8DlFYrUST
+S/CoBey/WOW9jPT/A8EBnp8RmPtAJH88qklbqh/YCoKyKZrgqT5IGysRLWwDFrGT
+QoOvR1a6SaVMLskmYUCkl8Yz8sZS58X50ahxx5TB0I3xsoCmnMZt+cd2C/VXwhFz
+jCiEZIuQlSgQFW4LOFrxrXmI+MDOBWu4zvkztWOnTe+BNgrxndGVI6sdFGzWeNQx
+dQ9imn0UqGSkgnJEj7Lq67ey8Cuu6yYWexKI0N9UOcyL4FgaEdWiJ0t5KY6NElGI
+0jrZX7pwVf/pvbKW2zVm6nXjWJ/JFw==
+-----END PRIVATE KEY-----
+</key>
+<dh>
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEAqJI9Luwkfy0E95gqZyq031Fa1rUCW5aBoppgm4YHxGUL+fUQzveF
+U2+W5xzmZuxhyoN0PVqlPXoMi0xGyTW4ga8qMaIHDqQ/V8RNxQYJ+GEEiC46/2u9
+Co/HbGX9YXMm5nnNEtHepAHcJiRB6QbCjzVm06x5QfWifj/yTm9ycVfJXhQJiOkD
+j4y4vJbgrmIKWX8Nxj4Q8dCAJzZ2gFvMnW9XcbS9SYbyvS0DvoQG3gPTGcopv7x1
+NiOhrxcTcMjwi/2z6kxG0MJEZ1HOJ2xTtRReUGXkL0lhbVTzkX4V6ihWK4MZYqe+
+ozy/0gbPAB4dT1QNeSRXPOi9f81Oed0SoC83P0oiq3JRQq2g7aS9OiwqlRPnVnvH
+q7Uko6+nv8XLbANgbdLXc8I3K78TSedwofxI/atxKncEic0fHV5ai2IdEWt22qxj
+iWVyaiHlWtMosZvuepSPn3cAmfuj0dVPNiRoG97neN8XIOaVZNGmNnI4yM0JEA1h
+Ef4Lh4YpDdqk4Q/nC/zJev8PM1XC+Os1SsGH50YAn8q19TGzI26/Y4jWfqrHswsj
+6vF/lxDS5RRzLIqlEksm84MU1q0AFSe9FaW1NTtKR/PLO1QiSKr718BwzzrDNN9u
+KZJabQ9n1RgLSuMP9zk9A6GUPQ7cZ0fJchUPeuF8Cd7zAV7k4m0RA4MCAQI=
+-----END DH PARAMETERS-----
+</dh>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.3.18-alpine-3.4/Dockerfile
+++ b/variants/2.3.18-alpine-3.4/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.4
+
+RUN apk add --no-cache openvpn>=2.3.18 iptables
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/2.3.18-alpine-3.4/docker-compose.yml
+++ b/variants/2.3.18-alpine-3.4/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '2.1'
+services:
+  openvpn-server:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
+      - NAT_MASQUERADE=1
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/server.conf:/etc/openvpn/server.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    ports:
+      - 1194:1194/udp
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped

--- a/variants/2.3.18-alpine-3.4/docker-entrypoint.sh
+++ b/variants/2.3.18-alpine-3.4/docker-entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+# Env vars
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
+OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
+NAT=${NAT:-1}
+NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
+CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    echo "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
+
+# If no args are passed, run the entrypoint. If a flag is passed, run openvpn directly. Else, run the passed command
+if [ "$#" -eq 0 ]; then
+    # Provision
+    echo "Provisioning tun device"
+    mkdir -p /dev/net
+    if [ ! -c /dev/net/tun ]; then
+        mknod /dev/net/tun c 10 200
+    fi
+    if [ -f "$CUSTOM_FIREWALL_SCRIPT" ]; then
+        echo "Executing custom firewall script: $CUSTOM_FIREWALL_SCRIPT"
+        . "$CUSTOM_FIREWALL_SCRIPT"
+    else
+        echo "Not executing custom firewall script $CUSTOM_FIREWALL_SCRIPT because it does not exist"
+    fi
+    if [ "$NAT" = 1 ]; then
+        echo "NAT is enabled"
+        echo "Provisioning NAT iptables rules"
+        echo "NAT_INTERFACE: $NAT_INTERFACE"
+        if [ "$NAT_MASQUERADE" = 1 ]; then
+            echo "NAT_MASQUERADE is enabled"
+            iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+            if [ -n "$OPENVPN_ROUTES" ]; then
+                echo "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+                for r in $OPENVPN_ROUTES; do
+                    iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+                done
+            else
+                echo "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+            fi
+        else
+            echo "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
+        fi
+    else
+        echo "NAT is disabled."
+        echo "Not adding NAT iptables rules"
+    fi
+
+    echo "Listing iptables rules:"
+    iptables -L -nv
+    echo "Listing iptables NAT rules:"
+    iptables -L -nv -t nat
+
+    # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
+    set openvpn --cd /etc/openvpn --config "$OPENVPN_CONFIG_FILE"
+    echo "openvpn command line: $@"
+    exec "$@"
+elif [ "$#" -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    echo "openvpn command line: $@"
+    exec openvpn "$@"
+fi
+
+exec "$@"

--- a/variants/2.3.18-alpine-3.4/openvpn/client.conf
+++ b/variants/2.3.18-alpine-3.4/openvpn/client.conf
@@ -1,0 +1,258 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/client.conf
+client
+dev tun
+proto udp
+remote openvpn-server 1194
+remote-random
+# Push all traffic into the tunnel
+;redirect-gateway def1 bypass-dhcp
+resolv-retry infinite
+nobind
+user nobody
+group nobody
+persist-key
+persist-tun
+remote-cert-tls server
+cipher AES-256-CBC
+auth SHA512
+comp-lzo
+verb 4
+key-direction 1
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:4e:3e:ee:0c:a0:be:17:77:36:7e:3e:48:bf:5a:f3
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=client-01
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:b3:ef:25:0f:86:77:8e:9f:a4:42:02:f0:19:0e:
+                    20:0e:93:5e:67:78:17:99:a9:cd:06:84:fe:c1:ed:
+                    5b:c9:96:d1:82:ef:5f:a5:95:d7:de:99:97:84:cc:
+                    a8:28:13:69:2f:41:7a:d4:f0:ac:a7:a3:10:8a:31:
+                    c6:aa:14:dd:d0:5d:15:51:2c:e9:5e:3e:fe:f0:1c:
+                    d7:62:07:f7:fb:01:93:22:8f:4b:72:77:76:8a:14:
+                    fe:26:52:59:c8:59:b0:01:b6:cb:7a:2d:ba:0d:35:
+                    a2:8c:42:97:18:54:45:58:f1:69:ff:3b:ce:fd:71:
+                    a5:13:42:82:ca:e2:25:43:61:d6:34:1f:f6:f3:36:
+                    7f:c9:7d:a4:e2:83:f1:8f:b7:2d:cd:7f:cf:1a:90:
+                    a4:86:ce:c0:6b:36:b3:9e:90:d0:60:5c:ec:ac:70:
+                    f7:32:16:59:20:1f:27:a5:3c:00:a0:9b:63:30:41:
+                    a5:d3:63:37:9d:10:f7:f6:53:45:54:57:70:7e:06:
+                    a6:01:32:38:2c:2d:d1:11:4c:3f:57:25:5a:2c:2c:
+                    06:a0:20:bb:c0:95:fd:44:a8:0d:3a:b0:c9:a3:b2:
+                    77:ce:f7:f0:f5:c8:1c:a7:74:ba:b9:83:0b:3c:56:
+                    6f:18:cb:df:39:77:3a:69:18:57:be:48:7e:ab:2a:
+                    21:2d:b0:eb:4c:26:ae:93:f2:d9:0d:29:01:b8:2c:
+                    0b:5a:ec:8a:c0:fd:5d:1c:a7:6f:31:29:5d:5c:35:
+                    cd:0e:e0:97:86:07:af:5e:69:8e:e7:e1:f0:78:21:
+                    f3:15:c6:35:cd:e6:4b:65:d5:17:0b:87:6e:ea:39:
+                    44:96:ab:bc:fc:ee:27:85:fe:10:c4:77:96:25:cd:
+                    9a:66:ee:e4:36:fb:f0:c8:90:62:de:6d:f6:8c:19:
+                    76:c6:6d:c3:9c:a4:9f:80:ec:39:79:ba:32:36:b2:
+                    7d:93:3c:dc:58:c5:13:34:35:8a:7e:cb:cc:f0:9a:
+                    bb:39:dd:ca:bc:cf:c7:7a:8f:9b:60:f1:a8:e6:e4:
+                    41:62:82:cd:cc:d2:81:06:c1:5b:82:0c:49:88:e6:
+                    bd:39:b2:06:82:a0:fb:55:ba:fd:de:57:2f:40:84:
+                    07:b8:38:9a:49:6e:38:49:c0:b9:26:f7:7e:a9:9a:
+                    18:b3:27:b9:d9:b3:fb:7f:6d:9e:68:58:94:f7:b1:
+                    21:b5:ee:59:b0:7f:fc:0f:ab:00:c2:8e:94:34:09:
+                    c3:45:dd:4c:79:03:b8:bf:ce:55:8f:6e:6d:c9:ff:
+                    4c:5b:da:fb:eb:70:bd:c9:37:68:6e:03:e0:db:2f:
+                    6e:db:6c:d4:f0:1f:01:43:42:6e:f6:31:4b:8d:fb:
+                    21:1e:77
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                23:46:34:1C:74:3B:D8:21:40:4D:81:B3:58:9F:57:CB:0C:5E:90:FB
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+    Signature Algorithm: sha256WithRSAEncryption
+         3c:80:ef:a8:a1:94:bc:12:33:6c:19:2e:44:44:6c:20:8e:69:
+         f6:b8:21:ad:4b:f7:14:d6:bf:c3:8d:b0:87:d1:e2:55:df:c0:
+         fd:03:31:82:8a:82:dd:68:3d:61:1f:c4:89:eb:e6:07:b0:89:
+         1d:19:8b:ee:57:9f:87:d8:a2:d8:fe:84:ad:f1:18:9c:b5:93:
+         a1:17:48:41:1e:f7:12:1e:50:46:b7:57:93:6e:d5:0f:d5:84:
+         a8:8e:74:4f:ab:8a:ae:40:64:8a:a8:57:32:75:b6:82:20:10:
+         be:ab:70:0c:96:c7:30:f4:69:c7:c9:24:db:3a:bc:40:eb:ac:
+         ee:04:f3:58:4a:09:6e:42:01:b4:a5:77:e5:2b:01:05:c1:5c:
+         08:59:0b:e3:a9:7a:b4:3e:f9:41:8d:2b:e6:8e:40:27:07:07:
+         0d:b0:03:ba:c9:d2:cd:dd:3c:9a:7e:20:66:bb:7f:4f:9d:fc:
+         37:16:88:84:a1:26:6a:91:43:d1:47:82:cb:e1:84:d4:03:93:
+         ec:8d:14:ce:2c:c8:fc:96:f8:28:d5:cb:89:c8:84:ee:8a:54:
+         8e:3c:12:86:10:73:78:5c:b8:a5:7d:99:94:b1:e1:f9:18:ed:
+         4b:2f:ae:8d:d4:9b:bc:20:21:d3:13:ed:07:15:70:dc:d1:1f:
+         58:22:fc:0e:5a:49:4e:6f:c1:99:9d:de:71:4e:62:7d:ad:d3:
+         2e:c3:ca:3f:db:cf:f3:46:aa:95:1f:99:1c:81:f8:15:5a:a1:
+         30:f7:7b:4a:e1:8a:fa:8b:a4:92:6d:11:e3:4c:f5:2b:b9:a3:
+         6d:a4:07:93:cb:28:f7:06:c1:e8:1b:1e:c5:aa:76:51:7e:1b:
+         a7:fe:db:9b:d4:23:d1:2a:16:52:ed:d1:2c:55:2b:cd:db:73:
+         fa:20:1a:18:47:af:90:50:0c:fe:1b:0d:f6:06:ec:33:1f:8e:
+         6f:f2:9a:d0:49:88:cb:a0:8c:8a:60:54:8e:d0:c1:59:ad:e6:
+         6e:6a:3e:e4:3b:b4:1b:01:8e:81:a4:f2:21:94:d1:a7:5e:e8:
+         1a:14:af:f1:46:5d:6a:ad:9d:06:02:84:58:96:b2:e6:f8:02:
+         5f:ce:ed:87:54:b5:f9:b6:62:97:51:b2:88:05:49:de:fd:56:
+         d1:67:e5:59:78:31:82:36:17:ce:07:62:81:5c:19:82:48:22:
+         88:15:ea:d9:fc:1e:c3:ee:05:a5:ec:e9:ca:69:b5:2a:7e:79:
+         ed:aa:6e:3f:b5:45:75:0b:d4:27:e4:4c:88:04:e0:06:36:5e:
+         41:37:b0:f5:44:80:58:86:dc:c1:be:82:62:fe:a8:2c:6c:ca:
+         6a:f8:dd:fd:85:df:5a:41
+-----BEGIN CERTIFICATE-----
+MIIFUTCCAzmgAwIBAgIQDU4+7gygvhd3Nn4+SL9a8zANBgkqhkiG9w0BAQsFADAT
+MREwDwYDVQQDDAhDaGFuZ2VNZTAeFw0yMzA2MzAxMTQ1MTJaFw0yNTEwMDIxMTQ1
+MTJaMBQxEjAQBgNVBAMMCWNsaWVudC0wMTCCAiIwDQYJKoZIhvcNAQEBBQADggIP
+ADCCAgoCggIBALPvJQ+Gd46fpEIC8BkOIA6TXmd4F5mpzQaE/sHtW8mW0YLvX6WV
+196Zl4TMqCgTaS9BetTwrKejEIoxxqoU3dBdFVEs6V4+/vAc12IH9/sBkyKPS3J3
+dooU/iZSWchZsAG2y3otug01ooxClxhURVjxaf87zv1xpRNCgsriJUNh1jQf9vM2
+f8l9pOKD8Y+3Lc1/zxqQpIbOwGs2s56Q0GBc7Kxw9zIWWSAfJ6U8AKCbYzBBpdNj
+N50Q9/ZTRVRXcH4GpgEyOCwt0RFMP1clWiwsBqAgu8CV/USoDTqwyaOyd8738PXI
+HKd0urmDCzxWbxjL3zl3OmkYV75IfqsqIS2w60wmrpPy2Q0pAbgsC1rsisD9XRyn
+bzEpXVw1zQ7gl4YHr15pjufh8Hgh8xXGNc3mS2XVFwuHbuo5RJarvPzuJ4X+EMR3
+liXNmmbu5Db78MiQYt5t9owZdsZtw5ykn4DsOXm6MjayfZM83FjFEzQ1in7LzPCa
+uzndyrzPx3qPm2DxqObkQWKCzczSgQbBW4IMSYjmvTmyBoKg+1W6/d5XL0CEB7g4
+mkluOEnAuSb3fqmaGLMnudmz+39tnmhYlPexIbXuWbB//A+rAMKOlDQJw0XdTHkD
+uL/OVY9ubcn/TFva++twvck3aG4D4Nsvbtts1PAfAUNCbvYxS437IR53AgMBAAGj
+gZ8wgZwwCQYDVR0TBAIwADAdBgNVHQ4EFgQUI0Y0HHQ72CFATYGzWJ9XywxekPsw
+TgYDVR0jBEcwRYAUmBuw7bvaYZi1OnrIxE4ycKX4qQehF6QVMBMxETAPBgNVBAMM
+CENoYW5nZU1lghQRFLv/ZzUIweAY3+3bxHLwDm1FLDATBgNVHSUEDDAKBggrBgEF
+BQcDAjALBgNVHQ8EBAMCB4AwDQYJKoZIhvcNAQELBQADggIBADyA76ihlLwSM2wZ
+LkREbCCOafa4Ia1L9xTWv8ONsIfR4lXfwP0DMYKKgt1oPWEfxInr5gewiR0Zi+5X
+n4fYotj+hK3xGJy1k6EXSEEe9xIeUEa3V5Nu1Q/VhKiOdE+riq5AZIqoVzJ1toIg
+EL6rcAyWxzD0acfJJNs6vEDrrO4E81hKCW5CAbSld+UrAQXBXAhZC+OperQ++UGN
+K+aOQCcHBw2wA7rJ0s3dPJp+IGa7f0+d/DcWiIShJmqRQ9FHgsvhhNQDk+yNFM4s
+yPyW+CjVy4nIhO6KVI48EoYQc3hcuKV9mZSx4fkY7Usvro3Um7wgIdMT7QcVcNzR
+H1gi/A5aSU5vwZmd3nFOYn2t0y7Dyj/bz/NGqpUfmRyB+BVaoTD3e0rhivqLpJJt
+EeNM9Su5o22kB5PLKPcGwegbHsWqdlF+G6f+25vUI9EqFlLt0SxVK83bc/ogGhhH
+r5BQDP4bDfYG7DMfjm/ymtBJiMugjIpgVI7QwVmt5m5qPuQ7tBsBjoGk8iGU0ade
+6BoUr/FGXWqtnQYChFiWsub4Al/O7YdUtfm2YpdRsogFSd79VtFn5Vl4MYI2F84H
+YoFcGYJIIogV6tn8HsPuBaXs6cpptSp+ee2qbj+1RXUL1CfkTIgE4AY2XkE3sPVE
+gFiG3MG+gmL+qCxsymr43f2F31pB
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQCz7yUPhneOn6RC
+AvAZDiAOk15neBeZqc0GhP7B7VvJltGC71+lldfemZeEzKgoE2kvQXrU8KynoxCK
+McaqFN3QXRVRLOlePv7wHNdiB/f7AZMij0tyd3aKFP4mUlnIWbABtst6LboNNaKM
+QpcYVEVY8Wn/O879caUTQoLK4iVDYdY0H/bzNn/JfaTig/GPty3Nf88akKSGzsBr
+NrOekNBgXOyscPcyFlkgHyelPACgm2MwQaXTYzedEPf2U0VUV3B+BqYBMjgsLdER
+TD9XJVosLAagILvAlf1EqA06sMmjsnfO9/D1yByndLq5gws8Vm8Yy985dzppGFe+
+SH6rKiEtsOtMJq6T8tkNKQG4LAta7IrA/V0cp28xKV1cNc0O4JeGB69eaY7n4fB4
+IfMVxjXN5ktl1RcLh27qOUSWq7z87ieF/hDEd5YlzZpm7uQ2+/DIkGLebfaMGXbG
+bcOcpJ+A7Dl5ujI2sn2TPNxYxRM0NYp+y8zwmrs53cq8z8d6j5tg8ajm5EFigs3M
+0oEGwVuCDEmI5r05sgaCoPtVuv3eVy9AhAe4OJpJbjhJwLkm936pmhizJ7nZs/t/
+bZ5oWJT3sSG17lmwf/wPqwDCjpQ0CcNF3Ux5A7i/zlWPbm3J/0xb2vvrcL3JN2hu
+A+DbL27bbNTwHwFDQm72MUuN+yEedwIDAQABAoICAAuYKlwwvv16vfve8pe6uEgY
+KOoj6+lj7qkv4raeU97OkBuOzyv9VtaqMQBGq8NBVPLNlluoUofO0x8EjBejlpN5
+nAkKCtOe3ZCdWyee+dS7yj5c23C5z/Kf3ayce9qUJOpHXB84WRfGz/2XwOK5c2qC
+y+C9et4L96YhEAqAvgP0hvf+40vSxDM4nGpYNDWdiR8H0FGW5nMlWXLPKI3cKQE8
+m6eU8+jPVdjjCQv1rNisipyubkAL0aaWVFQUE5CWvdHxHbtQABygqyshLaew6XmV
+MKwaz95eC97jsU6J28RnmJ7GjUlZJreHpwyTLCMsMqZ3ZJ/wVdw1zFmflEH1SgPq
+/JNd0OONKm8x7nORX9dHEn33Imfyg2jI6tzVx1oAmMWMb9hJ0XjkIyzjfHTPi5KW
+pM3pTUUn6ee4P1T4ReBlatiw2TFgAd18/9gSIaSlENEjslJGQ6/Ndt9O7UNHgwth
+ZNtPovjNLqUobHGXlmwg3haeBshn9iPcjdksAjgtjEyowzq7IpiSxQezXNcMezGM
+Y9UL5Qc/yjQ3t+Vu94Jmnu0TT3lHGWa3zSgI6L+UdBiIsLF6P5YQVloYOYWE3q/n
+HTaORoZlsRKfMIUHmhrZ1keJ4VGqLruSpQHobh3Cfb/xzgOEB3nSwhIK3l2FhSiR
+N9jb0r7kMElO+xlm7NChAoIBAQDllnlfyWnTBGog8+T9eJiODuBfdozy2vCZO8nc
+vp11NC7fLh5NXR16Ju6I+dcXDhPdoOG8H/DScjer82kEINrY7Wb4swNd01cLCg+/
+xVNe9iiLl4Q4m/QOI6ZOUbOfJjH9R8J4Bh/FzR1MXtVktgtsd6JB3zv6V246zDjy
+eMnOImwoj6TH/3hI/g2s5i3GoaC7CK+XjpdfZbVAX5+mnpZxBbOqXt7an1IzYHhx
+hQO8uo/9b2IDxMrWWn80mGj9Fw5AdK1Ef3eMtbyG6iOIR92UEo9ZwlZ9Tang58Sa
+7IFHZko/HcCrS92Hl9YcnYmjG0GDeFl4des+IcVz0AHDhe6RAoIBAQDIolXgCYO3
+zo2MtoBTCr+GcluT4DD16ALz7wd8/jXFqmD3UWCAeaS5IsTno1PmuIpvB7dvwz8B
+6SOpE//J/bECDmhE18UHYOAqkXzzuuEGMCP1TuaCWBq7kWV8GVTRcSGQDxLyf/Yu
+IdxiPQMaCxi0Ffv+aq27Nii1IyV8tyDL3skyGZeQJNW2xjNkngkXsB5Tp7H7tA0G
+lSmld1Rtq2XWcRnHQh9ZVP+FxwkjBkdoX0oAASVQwHsy9Q4hZ5ykxPkIGULj3Hw5
+zvG1RAM5B4GQegK0OfYuX5Ullrz6a/6p/FnGLvRkZGlHML/bHTmrr8ywSvF63Gkd
+oU0nqjPFQ1CHAoIBACoFR4PDno3TwgTz/tZxqyJdEK4ISbXtYpn5OnIfpTwdZ/LL
+QxqPz2RbGc+SQs7icbpfxtEi23X5F71uGKt7w/JuSSl9wkD6/HR1y/oiiKbZ0QPz
+oGyoBpxL5BVzmLepSv77kllbbZdLenBO7ym2tBKPNvBthlHEjNVQKaAfgXgsDrXB
+zLwaQw7BCQm7O2eej4eMCG9p1sTMHceBePwLDKf1DjRBlvJWtLnYj1LfsJZrYw1U
+xJDCBQoEmEGtH5IrFR2w/UGLPvtPDAl5czVvSdvfJcOc8S2P+GbEpNRiMys5Sp+Q
+t4HiqdI2dSbZoqZqx6vjbCTDGGJP1g7jZF8/9TECggEAXOXVj2O4an4oSnQiXNEI
+N29x+bl/0gy4eUw/El/+c+Tc+wbiAPrSC6sOsxaL/bOK3bgb9pLX9MGHcn1BHbzq
+ncIgA2hI4Y64nN06lvv7v0rBC4+Z6dZzok/DRr/P5x5T5Qklw8T+LwQcsBwB+KgU
+qyXWxUmN4bZFCQIaFHISrHMeg6UX6XU0w2loWHlYSnCQyjlGjv4iXd7pJqVnIVSQ
+VceOoRV7wHg7zCyJjX8Vxzz/3ZqqNYa6RLD09wCrphtSF67iqvDnUDkC7+Rq/Zf9
+JPFpmRuRYo19WKdAH0+r3fdrdfk9zdI0cPMgkosordc7lpFM2I9/2GlceTY0vGzb
+twKCAQEArUbkiwUZFjdjAbKS2m0uPJyytB8bZ335szcoMUV665hzU9EJPcWeVY0L
+1FSRu/cig+ZCmpUEc/4JhJVKLEEXgC3BgfHGNHi5PIuvssMT/fJJ9InQe8n4Zq0Q
+eZbrfAewrdH3bTpEf6AxIsrMioLsUQSV12iRQ7olsEP9t5HqRKqwhAnqp+q33XT3
+L++8IcaaEQ3S/sBb23pY+VSWQfKGFVQES+P7yKeNHjBNQpJTPOdM9iLtvriUmNdO
+Gy5HOpLgd10DzXBOI7CgqzFm69Bqk+WFZXGVd9T/Ku69B8XfshoRChGbgHbbEG70
+0xT4AQEuygYVBbUrIerZFpDD+Tw7ww==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.3.18-alpine-3.4/openvpn/firewall.sh
+++ b/variants/2.3.18-alpine-3.4/openvpn/firewall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# This iptables script to controlling traffic in the openvpn tunnel.
+# In this example, clients can only perform DNS, HTTP and HTTPS requests to the world.
+
+# Drop everything by default from tunnel to world
+iptables -P FORWARD DROP
+# Allow DNS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p udp -m udp --dport 53 -m conntrack --ctstate NEW -j ACCEPT
+# Allow HTTP and HTTPS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p tcp -m tcp -m conntrack --ctstate NEW -m multiport --dports 80,443 -j ACCEPT

--- a/variants/2.3.18-alpine-3.4/openvpn/server.conf
+++ b/variants/2.3.18-alpine-3.4/openvpn/server.conf
@@ -1,0 +1,280 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/server.conf
+port 1194
+proto udp
+dev tun
+server 10.8.0.0 255.255.255.0
+ifconfig-pool-persist tun-ipp.txt
+;client-config-dir ccd
+keepalive 10 120
+comp-lzo no
+max-clients 5
+user nobody
+group nogroup
+persist-key
+persist-tun
+status tun.status
+status-version 3
+;log-append server.log
+verb 4
+mute 20
+;duplicate-cn
+tls-version-min 1.2
+cipher AES-256-CBC
+auth SHA512
+key-direction 0
+;crl-verify crl.pem
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            97:80:c6:6b:b5:84:81:b3:2b:f6:56:55:da:67:4d:c8
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=server
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:be:f7:ee:15:bc:b6:e1:04:28:3e:38:6a:61:dd:
+                    ee:fa:61:85:9a:a7:be:44:22:52:b4:cf:7a:86:0e:
+                    21:ae:1e:2b:61:66:17:1f:54:dc:e9:75:27:55:24:
+                    39:fc:ee:92:d1:da:de:e2:5f:01:50:b6:ae:52:1a:
+                    79:6b:8d:56:0d:83:f6:d4:19:50:48:bc:cb:d8:69:
+                    c8:79:d4:ba:82:05:db:aa:58:12:4b:34:1b:15:d1:
+                    28:2d:b7:08:4e:a0:64:fb:c6:b4:e2:8b:61:68:4e:
+                    72:72:cc:da:a2:d8:cb:f5:6a:5d:13:b6:98:d3:0c:
+                    a3:05:7a:21:e3:f9:fb:de:89:be:37:ac:ce:4c:2e:
+                    95:98:9e:48:3c:04:97:cd:a3:36:92:15:12:a4:bf:
+                    46:ea:95:37:0c:6f:09:e1:51:f5:4e:13:9f:f5:68:
+                    65:0e:24:38:62:04:f8:f9:0c:06:72:c9:03:ed:5d:
+                    6f:40:3b:62:ea:a2:79:01:79:d0:58:aa:2c:7f:89:
+                    14:bc:3e:86:c0:5e:58:ac:58:c0:97:fe:65:57:46:
+                    bf:01:cc:d4:d7:64:d8:21:15:02:6b:6a:38:24:bb:
+                    2b:45:c7:79:23:7a:7f:0c:6b:25:d3:ce:e1:3f:e8:
+                    68:6c:31:7a:df:88:49:6d:a3:7e:22:24:08:3d:e1:
+                    6c:87:dd:34:77:d2:a5:eb:f7:e6:74:b9:e2:5f:e4:
+                    ad:49:e1:c0:b4:8f:d9:b5:ac:2d:7b:ba:22:64:8e:
+                    b7:c1:11:11:f1:e1:1f:b9:3e:29:b1:61:9b:8a:1c:
+                    2e:d4:e4:e6:10:5a:5d:e1:f9:1e:54:7b:13:79:dd:
+                    d9:ad:8b:23:c4:8d:a5:8b:f5:17:eb:99:96:5d:c6:
+                    8d:b4:af:8b:4c:2f:08:4d:37:c3:bf:6d:68:99:c4:
+                    f7:47:cc:5d:44:e7:6e:f2:64:b3:7d:bb:9b:c7:e1:
+                    27:cf:73:8d:b2:e2:88:19:6c:bb:6e:cd:4a:0a:79:
+                    a8:7b:9d:c3:b0:59:93:51:20:a1:d8:a2:0f:e5:62:
+                    76:17:b3:bb:aa:bc:3a:73:e7:f6:57:91:6a:cb:d3:
+                    7e:91:38:5e:88:57:e3:d8:3e:31:cd:dc:69:9a:74:
+                    bb:6e:62:c2:ab:5b:8c:f5:80:ff:b4:98:a2:87:15:
+                    72:38:77:76:dc:e2:d1:ac:2f:66:67:ae:c4:33:a8:
+                    86:94:af:41:b1:99:0d:5d:68:df:9a:ec:86:0f:0a:
+                    c9:67:fa:a1:7c:29:47:d3:f1:c1:3d:8a:d1:a4:12:
+                    a6:70:16:37:80:4f:d9:79:61:45:1c:07:77:68:60:
+                    4e:10:ec:94:dd:03:95:b1:37:cc:88:3d:60:cc:32:
+                    37:be:a5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                4A:91:C2:3E:A1:E9:04:C9:C0:9A:8B:CE:D4:37:4D:96:0E:74:FE:90
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication
+            X509v3 Key Usage:
+                Digital Signature, Key Encipherment
+            X509v3 Subject Alternative Name:
+                DNS:server
+    Signature Algorithm: sha256WithRSAEncryption
+         72:b4:75:02:f7:7b:e9:07:c6:79:1b:bb:11:e4:73:4a:b4:76:
+         1c:03:b9:58:8c:0a:80:f0:c6:8c:cc:2a:a7:c7:8c:57:a8:6e:
+         52:19:f0:b5:7c:0f:06:ab:2f:04:0e:99:32:b9:2c:b6:42:f0:
+         f5:5b:97:32:ce:bb:0c:ee:9f:b0:0b:bc:0b:c0:43:1d:7d:04:
+         b4:a1:cf:a0:aa:fe:f1:cc:b4:31:b3:bb:78:ed:0e:60:8d:37:
+         ea:48:a7:b4:2d:6d:64:6e:97:15:aa:e4:9b:b4:68:79:c8:3b:
+         ba:91:0b:db:cd:04:a3:aa:e4:69:59:06:ec:50:68:6d:0d:a6:
+         38:32:55:76:09:10:00:da:ac:a8:9e:ad:ad:95:8f:01:88:c9:
+         40:af:9a:5c:2d:17:34:81:6b:26:65:8a:e5:2a:15:79:13:2d:
+         ae:d8:03:16:6b:e9:b6:cd:f3:cb:d5:4d:5f:40:76:7a:99:99:
+         d5:2f:e8:a1:59:88:01:6b:a1:36:c0:53:dc:46:07:fd:ab:ab:
+         2a:5b:d3:d5:4c:84:c2:fb:48:16:80:80:01:f6:37:80:3a:54:
+         81:11:24:86:a6:a2:9a:73:06:5f:ca:24:8c:20:3a:40:6e:95:
+         8e:44:46:ef:60:bc:9d:11:ad:71:af:61:85:a6:e2:b4:49:c7:
+         fa:bb:ef:b5:c9:02:d2:a2:a5:3b:f6:46:03:dc:58:9f:ff:dc:
+         23:6b:b5:02:4c:1a:1a:80:99:6d:1a:fd:24:fc:32:83:f7:de:
+         fd:2b:b2:45:b7:3b:89:3c:49:0c:3d:0b:05:67:a5:95:00:3d:
+         cd:a7:0a:3b:b5:cd:02:10:09:de:ff:6c:6b:8b:aa:9d:e6:e9:
+         07:83:e2:dd:de:6d:bc:9e:fd:19:77:30:5d:67:12:c2:33:40:
+         0f:13:69:98:02:ef:05:b2:ad:ef:fb:73:15:57:70:46:83:32:
+         a9:05:4d:31:06:3d:44:93:88:69:de:9a:67:b4:6b:b7:0d:6b:
+         69:24:8b:62:52:f7:85:66:8f:84:2d:c0:a7:ff:33:37:7c:f3:
+         d1:1f:8c:b6:16:a3:98:db:6e:aa:e5:eb:d8:ed:06:31:19:ba:
+         01:f1:e6:3e:bc:78:ec:6e:b4:af:6c:8a:49:0f:ff:5a:f0:00:
+         88:d8:66:af:d6:49:31:b5:54:ce:be:07:59:46:bb:67:73:4b:
+         b8:ec:be:16:04:ed:fe:75:57:21:d6:d5:7b:cc:d0:7c:bd:91:
+         d3:6e:61:72:04:30:24:45:0a:0d:16:b6:35:94:49:02:14:8d:
+         2d:1d:71:42:13:9a:02:1e:3c:31:05:b4:76:5b:dd:ff:bb:db:
+         f4:31:b7:47:bb:54:f8:27
+-----BEGIN CERTIFICATE-----
+MIIFYjCCA0qgAwIBAgIRAJeAxmu1hIGzK/ZWVdpnTcgwDQYJKoZIhvcNAQELBQAw
+EzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMjUxMDAyMTE0
+NTEyWjARMQ8wDQYDVQQDDAZzZXJ2ZXIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+ggIKAoICAQC+9+4VvLbhBCg+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzp
+dSdVJDn87pLR2t7iXwFQtq5SGnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV
+0SgttwhOoGT7xrTii2FoTnJyzNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWY
+nkg8BJfNozaSFRKkv0bqlTcMbwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2Lq
+onkBedBYqix/iRS8PobAXlisWMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8M
+ayXTzuE/6GhsMXrfiElto34iJAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17
+uiJkjrfBERHx4R+5PimxYZuKHC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZd
+xo20r4tMLwhNN8O/bWiZxPdHzF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7
+ncOwWZNRIKHYog/lYnYXs7uqvDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKr
+W4z1gP+0mKKHFXI4d3bc4tGsL2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT
+8cE9itGkEqZwFjeAT9l5YUUcB3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABo4Gy
+MIGvMAkGA1UdEwQCMAAwHQYDVR0OBBYEFEqRwj6h6QTJwJqLztQ3TZYOdP6QME4G
+A1UdIwRHMEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhD
+aGFuZ2VNZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwEwYDVR0lBAwwCgYIKwYBBQUH
+AwEwCwYDVR0PBAQDAgWgMBEGA1UdEQQKMAiCBnNlcnZlcjANBgkqhkiG9w0BAQsF
+AAOCAgEAcrR1Avd76QfGeRu7EeRzSrR2HAO5WIwKgPDGjMwqp8eMV6huUhnwtXwP
+BqsvBA6ZMrkstkLw9VuXMs67DO6fsAu8C8BDHX0EtKHPoKr+8cy0MbO7eO0OYI03
+6kintC1tZG6XFarkm7Roecg7upEL280Eo6rkaVkG7FBobQ2mODJVdgkQANqsqJ6t
+rZWPAYjJQK+aXC0XNIFrJmWK5SoVeRMtrtgDFmvpts3zy9VNX0B2epmZ1S/ooVmI
+AWuhNsBT3EYH/aurKlvT1UyEwvtIFoCAAfY3gDpUgREkhqaimnMGX8okjCA6QG6V
+jkRG72C8nRGtca9hhabitEnH+rvvtckC0qKlO/ZGA9xYn//cI2u1AkwaGoCZbRr9
+JPwyg/fe/SuyRbc7iTxJDD0LBWellQA9zacKO7XNAhAJ3v9sa4uqnebpB4Pi3d5t
+vJ79GXcwXWcSwjNADxNpmALvBbKt7/tzFVdwRoMyqQVNMQY9RJOIad6aZ7Rrtw1r
+aSSLYlL3hWaPhC3Ap/8zN3zz0R+MthajmNtuquXr2O0GMRm6AfHmPrx47G60r2yK
+SQ//WvAAiNhmr9ZJMbVUzr4HWUa7Z3NLuOy+FgTt/nVXIdbVe8zQfL2R025hcgQw
+JEUKDRa2NZRJAhSNLR1xQhOaAh48MQW0dlvd/7vb9DG3R7tU+Cc=
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQC+9+4VvLbhBCg+
+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzpdSdVJDn87pLR2t7iXwFQtq5S
+GnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV0SgttwhOoGT7xrTii2FoTnJy
+zNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWYnkg8BJfNozaSFRKkv0bqlTcM
+bwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2LqonkBedBYqix/iRS8PobAXlis
+WMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8MayXTzuE/6GhsMXrfiElto34i
+JAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17uiJkjrfBERHx4R+5PimxYZuK
+HC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZdxo20r4tMLwhNN8O/bWiZxPdH
+zF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7ncOwWZNRIKHYog/lYnYXs7uq
+vDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKrW4z1gP+0mKKHFXI4d3bc4tGs
+L2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT8cE9itGkEqZwFjeAT9l5YUUc
+B3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABAoICAAnfT1OYWevwBxSQXg+JJZ2U
+BRAls9RZ4eSvBSqA+ITD0oJKgM+B15nKEKp6IPVOcBChO/x/5NWDXCeqbrR8rgIs
+3EnCtT/NYsxhS5fgw3ONUfnQa8Gvg+bw1R7n42oNKKtLbnZ3tiVqSMhehr78bi7V
+vNIUEnp2oMbbtXzPo5GxlT/TkyalEd698AYKRr6+vUd4B2q06Lmf1SSzaNNZJVFP
++mj5aJ/+h1up3iUh1gOBGM7gkavEZiyzEYZeAcNTqNE/CO9iXBz9w5/FRs+UuzBz
+29P//tDTyciMCX/8EcL0WhxVX5HR91dxApecjlB7d0qAlFWR+hnM5exl6HcqfC3C
++Uhi5IC+gZjD2KCcHDr9e5WqQ6cu8TeMnoyuHInIV9kUL3Bn1ArOU1dmGS78soeE
+GpqGCRc9Imh8jxs1AVyj9wGzpfuRS8OBpfR5MIlcFwSlZO/6dnJSaF2BH1jnKgBG
+Xn9MvjfHTU/EhLTteXrAJlqQr4e/uAK5QCESFNXLvC0r3qord6b9Y0zHR63SpESJ
+WVUIF9L2fIh0Z4CutPegcbEyWLaaAT4njyR4uCI78g77kK+PGi2NM65Mk+wKt975
+m3Qh4/cNv1ews4h+RflayWC9kiiRVzDHJGTy63k5gdplqrW2rb8gK3ZQaT2gQp9u
+gjKIIFGyi+EIDSukHNdRAoIBAQDuGvE9k1lSvoPgSusogMk7PWTiZbn8MwlEFueM
+ZJk9k8dMSkqF1k5BXG9lHcWuFl2invgTiFJIF7ML0GDsFJR+CzCDsanSGdjyKfGM
+HzHAc7UPAJYBXPX1rxTAhGSirKjArcqYUX3ZGGaTo1yZrsbbarInUhWWNKFBdaQ+
++L3oClGt3GZx7hdxapI/3gnkLvG/C5hWWetLONZAxY6jwJJSA/p2Fx93SlWOtrmT
+KRbM/p8m6sHtsXcBnYTueqWYpJ2mnBIB+Svf5acqQ2Xf8kAIw4Vw9u7a15OlIDGF
+ouWhtSkL4s0YfZjlXswOPZDlF3eT2ilf+OIjv5kEcLdDKOojAoIBAQDNUhfys2TH
+b1NFsIH6X1jtWHUEGOYIM/y/75Vw2pGLb40cMxVPtzsNCvz8id/sCuvx6yUWlBlN
+wjpa+7dOA+FgoXwv1iVsQm1zQlrt2VKaEy29C0tRkSwOjNC0bz1409wzYNnh5Bdx
+KJDvSz9zlefAryJGTSgGOothOjnguzoEJ6DxfkxNyWbxceBgN8JljDhc9dcybKdD
+Uxy2GflXhZvZfCtTbYfWoIV+dTYyZt2QE4PEPXrJHGUFE9ncGynbzAn1Cc/zGBeT
+zFNoYOCWNr7ueRNHQYMRZ1N3dYRdZ9th5mdqqa1eY5lP4PyQYZV6lwmyEfitXwNz
+vhS0sO+pNAyXAoIBAB9OiZOoESGRDTPrhdnwfQT+AIrIB1lCuKAsRsut2nw/NwAv
+8HaChA2SAs+Px5MpO6yLLGEdFnyGKTOPdX71AcVE4V8feA24+k50916OJ3N/gzny
+wMZzG5/vIlJh1f2RqCqVb0LxzBNEYxBcdWt7kIf/EmebIl16lA1QU4U4HXgqCy1K
+AmpOfOSbt5kQL8rB5WVSN/h6oDZmxb0EfMnJIzQHc+IdDjUYIAHAwsu3pljTzcdH
+LLJ9GAGtXXIhzC4yzsu+T5vU0FEDGCS1ceqtJoBAfQYqYaOCntYiUoCYt4q4kCoQ
+6xiiQv09pqTksW191WoqUDBfQBSlN5Be5am98nMCggEAIzEb+7R15J0XN82uKZzo
+IB5WSDKAUw2eF8PX6HT+F1kyZY/36ibszyp//EUhhVLF6Dw2qi0OPT66Q9f7LjsK
+CUcEgyqAVZL5MZVBAp2KQ/BfmZRy/3MTixbluteKQMiHaKMEFWzD+9hJJ0rNgGFE
+TMl35XbaEl88fpi9TOCqbAXi1yGfsIGBzIaJP9Su1Dr5ei2FChaHgMmhFTFUhITZ
+FqjqwCz46HexCeDLPk5VUZmWry8eeZQNWJZzc/+P6CWL210oMHGDsQiHj09zjyup
+BDTqcf8vmO8N5l7VJjFj797PAQA+P/xwTbmxcInZVh7HQadE6WpsrAz7fZEKMwVB
+1wKCAQEA3oqXI9bGGoXFjydUiNMZbuHdIDQCa9t7iDb+J+NAiA7GI8W8DlFYrUST
+S/CoBey/WOW9jPT/A8EBnp8RmPtAJH88qklbqh/YCoKyKZrgqT5IGysRLWwDFrGT
+QoOvR1a6SaVMLskmYUCkl8Yz8sZS58X50ahxx5TB0I3xsoCmnMZt+cd2C/VXwhFz
+jCiEZIuQlSgQFW4LOFrxrXmI+MDOBWu4zvkztWOnTe+BNgrxndGVI6sdFGzWeNQx
+dQ9imn0UqGSkgnJEj7Lq67ey8Cuu6yYWexKI0N9UOcyL4FgaEdWiJ0t5KY6NElGI
+0jrZX7pwVf/pvbKW2zVm6nXjWJ/JFw==
+-----END PRIVATE KEY-----
+</key>
+<dh>
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEAqJI9Luwkfy0E95gqZyq031Fa1rUCW5aBoppgm4YHxGUL+fUQzveF
+U2+W5xzmZuxhyoN0PVqlPXoMi0xGyTW4ga8qMaIHDqQ/V8RNxQYJ+GEEiC46/2u9
+Co/HbGX9YXMm5nnNEtHepAHcJiRB6QbCjzVm06x5QfWifj/yTm9ycVfJXhQJiOkD
+j4y4vJbgrmIKWX8Nxj4Q8dCAJzZ2gFvMnW9XcbS9SYbyvS0DvoQG3gPTGcopv7x1
+NiOhrxcTcMjwi/2z6kxG0MJEZ1HOJ2xTtRReUGXkL0lhbVTzkX4V6ihWK4MZYqe+
+ozy/0gbPAB4dT1QNeSRXPOi9f81Oed0SoC83P0oiq3JRQq2g7aS9OiwqlRPnVnvH
+q7Uko6+nv8XLbANgbdLXc8I3K78TSedwofxI/atxKncEic0fHV5ai2IdEWt22qxj
+iWVyaiHlWtMosZvuepSPn3cAmfuj0dVPNiRoG97neN8XIOaVZNGmNnI4yM0JEA1h
+Ef4Lh4YpDdqk4Q/nC/zJev8PM1XC+Os1SsGH50YAn8q19TGzI26/Y4jWfqrHswsj
+6vF/lxDS5RRzLIqlEksm84MU1q0AFSe9FaW1NTtKR/PLO1QiSKr718BwzzrDNN9u
+KZJabQ9n1RgLSuMP9zk9A6GUPQ7cZ0fJchUPeuF8Cd7zAV7k4m0RA4MCAQI=
+-----END DH PARAMETERS-----
+</dh>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.3.18-alpine-3.5/Dockerfile
+++ b/variants/2.3.18-alpine-3.5/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.5
+
+RUN apk add --no-cache openvpn>=2.3.18 iptables
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/2.3.18-alpine-3.5/docker-compose.yml
+++ b/variants/2.3.18-alpine-3.5/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '2.1'
+services:
+  openvpn-server:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
+      - NAT_MASQUERADE=1
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/server.conf:/etc/openvpn/server.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    ports:
+      - 1194:1194/udp
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped

--- a/variants/2.3.18-alpine-3.5/docker-entrypoint.sh
+++ b/variants/2.3.18-alpine-3.5/docker-entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+# Env vars
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
+OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
+NAT=${NAT:-1}
+NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
+CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    echo "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
+
+# If no args are passed, run the entrypoint. If a flag is passed, run openvpn directly. Else, run the passed command
+if [ "$#" -eq 0 ]; then
+    # Provision
+    echo "Provisioning tun device"
+    mkdir -p /dev/net
+    if [ ! -c /dev/net/tun ]; then
+        mknod /dev/net/tun c 10 200
+    fi
+    if [ -f "$CUSTOM_FIREWALL_SCRIPT" ]; then
+        echo "Executing custom firewall script: $CUSTOM_FIREWALL_SCRIPT"
+        . "$CUSTOM_FIREWALL_SCRIPT"
+    else
+        echo "Not executing custom firewall script $CUSTOM_FIREWALL_SCRIPT because it does not exist"
+    fi
+    if [ "$NAT" = 1 ]; then
+        echo "NAT is enabled"
+        echo "Provisioning NAT iptables rules"
+        echo "NAT_INTERFACE: $NAT_INTERFACE"
+        if [ "$NAT_MASQUERADE" = 1 ]; then
+            echo "NAT_MASQUERADE is enabled"
+            iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+            if [ -n "$OPENVPN_ROUTES" ]; then
+                echo "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+                for r in $OPENVPN_ROUTES; do
+                    iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+                done
+            else
+                echo "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+            fi
+        else
+            echo "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
+        fi
+    else
+        echo "NAT is disabled."
+        echo "Not adding NAT iptables rules"
+    fi
+
+    echo "Listing iptables rules:"
+    iptables -L -nv
+    echo "Listing iptables NAT rules:"
+    iptables -L -nv -t nat
+
+    # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
+    set openvpn --cd /etc/openvpn --config "$OPENVPN_CONFIG_FILE"
+    echo "openvpn command line: $@"
+    exec "$@"
+elif [ "$#" -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    echo "openvpn command line: $@"
+    exec openvpn "$@"
+fi
+
+exec "$@"

--- a/variants/2.3.18-alpine-3.5/openvpn/client.conf
+++ b/variants/2.3.18-alpine-3.5/openvpn/client.conf
@@ -1,0 +1,258 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/client.conf
+client
+dev tun
+proto udp
+remote openvpn-server 1194
+remote-random
+# Push all traffic into the tunnel
+;redirect-gateway def1 bypass-dhcp
+resolv-retry infinite
+nobind
+user nobody
+group nobody
+persist-key
+persist-tun
+remote-cert-tls server
+cipher AES-256-CBC
+auth SHA512
+comp-lzo
+verb 4
+key-direction 1
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:4e:3e:ee:0c:a0:be:17:77:36:7e:3e:48:bf:5a:f3
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=client-01
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:b3:ef:25:0f:86:77:8e:9f:a4:42:02:f0:19:0e:
+                    20:0e:93:5e:67:78:17:99:a9:cd:06:84:fe:c1:ed:
+                    5b:c9:96:d1:82:ef:5f:a5:95:d7:de:99:97:84:cc:
+                    a8:28:13:69:2f:41:7a:d4:f0:ac:a7:a3:10:8a:31:
+                    c6:aa:14:dd:d0:5d:15:51:2c:e9:5e:3e:fe:f0:1c:
+                    d7:62:07:f7:fb:01:93:22:8f:4b:72:77:76:8a:14:
+                    fe:26:52:59:c8:59:b0:01:b6:cb:7a:2d:ba:0d:35:
+                    a2:8c:42:97:18:54:45:58:f1:69:ff:3b:ce:fd:71:
+                    a5:13:42:82:ca:e2:25:43:61:d6:34:1f:f6:f3:36:
+                    7f:c9:7d:a4:e2:83:f1:8f:b7:2d:cd:7f:cf:1a:90:
+                    a4:86:ce:c0:6b:36:b3:9e:90:d0:60:5c:ec:ac:70:
+                    f7:32:16:59:20:1f:27:a5:3c:00:a0:9b:63:30:41:
+                    a5:d3:63:37:9d:10:f7:f6:53:45:54:57:70:7e:06:
+                    a6:01:32:38:2c:2d:d1:11:4c:3f:57:25:5a:2c:2c:
+                    06:a0:20:bb:c0:95:fd:44:a8:0d:3a:b0:c9:a3:b2:
+                    77:ce:f7:f0:f5:c8:1c:a7:74:ba:b9:83:0b:3c:56:
+                    6f:18:cb:df:39:77:3a:69:18:57:be:48:7e:ab:2a:
+                    21:2d:b0:eb:4c:26:ae:93:f2:d9:0d:29:01:b8:2c:
+                    0b:5a:ec:8a:c0:fd:5d:1c:a7:6f:31:29:5d:5c:35:
+                    cd:0e:e0:97:86:07:af:5e:69:8e:e7:e1:f0:78:21:
+                    f3:15:c6:35:cd:e6:4b:65:d5:17:0b:87:6e:ea:39:
+                    44:96:ab:bc:fc:ee:27:85:fe:10:c4:77:96:25:cd:
+                    9a:66:ee:e4:36:fb:f0:c8:90:62:de:6d:f6:8c:19:
+                    76:c6:6d:c3:9c:a4:9f:80:ec:39:79:ba:32:36:b2:
+                    7d:93:3c:dc:58:c5:13:34:35:8a:7e:cb:cc:f0:9a:
+                    bb:39:dd:ca:bc:cf:c7:7a:8f:9b:60:f1:a8:e6:e4:
+                    41:62:82:cd:cc:d2:81:06:c1:5b:82:0c:49:88:e6:
+                    bd:39:b2:06:82:a0:fb:55:ba:fd:de:57:2f:40:84:
+                    07:b8:38:9a:49:6e:38:49:c0:b9:26:f7:7e:a9:9a:
+                    18:b3:27:b9:d9:b3:fb:7f:6d:9e:68:58:94:f7:b1:
+                    21:b5:ee:59:b0:7f:fc:0f:ab:00:c2:8e:94:34:09:
+                    c3:45:dd:4c:79:03:b8:bf:ce:55:8f:6e:6d:c9:ff:
+                    4c:5b:da:fb:eb:70:bd:c9:37:68:6e:03:e0:db:2f:
+                    6e:db:6c:d4:f0:1f:01:43:42:6e:f6:31:4b:8d:fb:
+                    21:1e:77
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                23:46:34:1C:74:3B:D8:21:40:4D:81:B3:58:9F:57:CB:0C:5E:90:FB
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+    Signature Algorithm: sha256WithRSAEncryption
+         3c:80:ef:a8:a1:94:bc:12:33:6c:19:2e:44:44:6c:20:8e:69:
+         f6:b8:21:ad:4b:f7:14:d6:bf:c3:8d:b0:87:d1:e2:55:df:c0:
+         fd:03:31:82:8a:82:dd:68:3d:61:1f:c4:89:eb:e6:07:b0:89:
+         1d:19:8b:ee:57:9f:87:d8:a2:d8:fe:84:ad:f1:18:9c:b5:93:
+         a1:17:48:41:1e:f7:12:1e:50:46:b7:57:93:6e:d5:0f:d5:84:
+         a8:8e:74:4f:ab:8a:ae:40:64:8a:a8:57:32:75:b6:82:20:10:
+         be:ab:70:0c:96:c7:30:f4:69:c7:c9:24:db:3a:bc:40:eb:ac:
+         ee:04:f3:58:4a:09:6e:42:01:b4:a5:77:e5:2b:01:05:c1:5c:
+         08:59:0b:e3:a9:7a:b4:3e:f9:41:8d:2b:e6:8e:40:27:07:07:
+         0d:b0:03:ba:c9:d2:cd:dd:3c:9a:7e:20:66:bb:7f:4f:9d:fc:
+         37:16:88:84:a1:26:6a:91:43:d1:47:82:cb:e1:84:d4:03:93:
+         ec:8d:14:ce:2c:c8:fc:96:f8:28:d5:cb:89:c8:84:ee:8a:54:
+         8e:3c:12:86:10:73:78:5c:b8:a5:7d:99:94:b1:e1:f9:18:ed:
+         4b:2f:ae:8d:d4:9b:bc:20:21:d3:13:ed:07:15:70:dc:d1:1f:
+         58:22:fc:0e:5a:49:4e:6f:c1:99:9d:de:71:4e:62:7d:ad:d3:
+         2e:c3:ca:3f:db:cf:f3:46:aa:95:1f:99:1c:81:f8:15:5a:a1:
+         30:f7:7b:4a:e1:8a:fa:8b:a4:92:6d:11:e3:4c:f5:2b:b9:a3:
+         6d:a4:07:93:cb:28:f7:06:c1:e8:1b:1e:c5:aa:76:51:7e:1b:
+         a7:fe:db:9b:d4:23:d1:2a:16:52:ed:d1:2c:55:2b:cd:db:73:
+         fa:20:1a:18:47:af:90:50:0c:fe:1b:0d:f6:06:ec:33:1f:8e:
+         6f:f2:9a:d0:49:88:cb:a0:8c:8a:60:54:8e:d0:c1:59:ad:e6:
+         6e:6a:3e:e4:3b:b4:1b:01:8e:81:a4:f2:21:94:d1:a7:5e:e8:
+         1a:14:af:f1:46:5d:6a:ad:9d:06:02:84:58:96:b2:e6:f8:02:
+         5f:ce:ed:87:54:b5:f9:b6:62:97:51:b2:88:05:49:de:fd:56:
+         d1:67:e5:59:78:31:82:36:17:ce:07:62:81:5c:19:82:48:22:
+         88:15:ea:d9:fc:1e:c3:ee:05:a5:ec:e9:ca:69:b5:2a:7e:79:
+         ed:aa:6e:3f:b5:45:75:0b:d4:27:e4:4c:88:04:e0:06:36:5e:
+         41:37:b0:f5:44:80:58:86:dc:c1:be:82:62:fe:a8:2c:6c:ca:
+         6a:f8:dd:fd:85:df:5a:41
+-----BEGIN CERTIFICATE-----
+MIIFUTCCAzmgAwIBAgIQDU4+7gygvhd3Nn4+SL9a8zANBgkqhkiG9w0BAQsFADAT
+MREwDwYDVQQDDAhDaGFuZ2VNZTAeFw0yMzA2MzAxMTQ1MTJaFw0yNTEwMDIxMTQ1
+MTJaMBQxEjAQBgNVBAMMCWNsaWVudC0wMTCCAiIwDQYJKoZIhvcNAQEBBQADggIP
+ADCCAgoCggIBALPvJQ+Gd46fpEIC8BkOIA6TXmd4F5mpzQaE/sHtW8mW0YLvX6WV
+196Zl4TMqCgTaS9BetTwrKejEIoxxqoU3dBdFVEs6V4+/vAc12IH9/sBkyKPS3J3
+dooU/iZSWchZsAG2y3otug01ooxClxhURVjxaf87zv1xpRNCgsriJUNh1jQf9vM2
+f8l9pOKD8Y+3Lc1/zxqQpIbOwGs2s56Q0GBc7Kxw9zIWWSAfJ6U8AKCbYzBBpdNj
+N50Q9/ZTRVRXcH4GpgEyOCwt0RFMP1clWiwsBqAgu8CV/USoDTqwyaOyd8738PXI
+HKd0urmDCzxWbxjL3zl3OmkYV75IfqsqIS2w60wmrpPy2Q0pAbgsC1rsisD9XRyn
+bzEpXVw1zQ7gl4YHr15pjufh8Hgh8xXGNc3mS2XVFwuHbuo5RJarvPzuJ4X+EMR3
+liXNmmbu5Db78MiQYt5t9owZdsZtw5ykn4DsOXm6MjayfZM83FjFEzQ1in7LzPCa
+uzndyrzPx3qPm2DxqObkQWKCzczSgQbBW4IMSYjmvTmyBoKg+1W6/d5XL0CEB7g4
+mkluOEnAuSb3fqmaGLMnudmz+39tnmhYlPexIbXuWbB//A+rAMKOlDQJw0XdTHkD
+uL/OVY9ubcn/TFva++twvck3aG4D4Nsvbtts1PAfAUNCbvYxS437IR53AgMBAAGj
+gZ8wgZwwCQYDVR0TBAIwADAdBgNVHQ4EFgQUI0Y0HHQ72CFATYGzWJ9XywxekPsw
+TgYDVR0jBEcwRYAUmBuw7bvaYZi1OnrIxE4ycKX4qQehF6QVMBMxETAPBgNVBAMM
+CENoYW5nZU1lghQRFLv/ZzUIweAY3+3bxHLwDm1FLDATBgNVHSUEDDAKBggrBgEF
+BQcDAjALBgNVHQ8EBAMCB4AwDQYJKoZIhvcNAQELBQADggIBADyA76ihlLwSM2wZ
+LkREbCCOafa4Ia1L9xTWv8ONsIfR4lXfwP0DMYKKgt1oPWEfxInr5gewiR0Zi+5X
+n4fYotj+hK3xGJy1k6EXSEEe9xIeUEa3V5Nu1Q/VhKiOdE+riq5AZIqoVzJ1toIg
+EL6rcAyWxzD0acfJJNs6vEDrrO4E81hKCW5CAbSld+UrAQXBXAhZC+OperQ++UGN
+K+aOQCcHBw2wA7rJ0s3dPJp+IGa7f0+d/DcWiIShJmqRQ9FHgsvhhNQDk+yNFM4s
+yPyW+CjVy4nIhO6KVI48EoYQc3hcuKV9mZSx4fkY7Usvro3Um7wgIdMT7QcVcNzR
+H1gi/A5aSU5vwZmd3nFOYn2t0y7Dyj/bz/NGqpUfmRyB+BVaoTD3e0rhivqLpJJt
+EeNM9Su5o22kB5PLKPcGwegbHsWqdlF+G6f+25vUI9EqFlLt0SxVK83bc/ogGhhH
+r5BQDP4bDfYG7DMfjm/ymtBJiMugjIpgVI7QwVmt5m5qPuQ7tBsBjoGk8iGU0ade
+6BoUr/FGXWqtnQYChFiWsub4Al/O7YdUtfm2YpdRsogFSd79VtFn5Vl4MYI2F84H
+YoFcGYJIIogV6tn8HsPuBaXs6cpptSp+ee2qbj+1RXUL1CfkTIgE4AY2XkE3sPVE
+gFiG3MG+gmL+qCxsymr43f2F31pB
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQCz7yUPhneOn6RC
+AvAZDiAOk15neBeZqc0GhP7B7VvJltGC71+lldfemZeEzKgoE2kvQXrU8KynoxCK
+McaqFN3QXRVRLOlePv7wHNdiB/f7AZMij0tyd3aKFP4mUlnIWbABtst6LboNNaKM
+QpcYVEVY8Wn/O879caUTQoLK4iVDYdY0H/bzNn/JfaTig/GPty3Nf88akKSGzsBr
+NrOekNBgXOyscPcyFlkgHyelPACgm2MwQaXTYzedEPf2U0VUV3B+BqYBMjgsLdER
+TD9XJVosLAagILvAlf1EqA06sMmjsnfO9/D1yByndLq5gws8Vm8Yy985dzppGFe+
+SH6rKiEtsOtMJq6T8tkNKQG4LAta7IrA/V0cp28xKV1cNc0O4JeGB69eaY7n4fB4
+IfMVxjXN5ktl1RcLh27qOUSWq7z87ieF/hDEd5YlzZpm7uQ2+/DIkGLebfaMGXbG
+bcOcpJ+A7Dl5ujI2sn2TPNxYxRM0NYp+y8zwmrs53cq8z8d6j5tg8ajm5EFigs3M
+0oEGwVuCDEmI5r05sgaCoPtVuv3eVy9AhAe4OJpJbjhJwLkm936pmhizJ7nZs/t/
+bZ5oWJT3sSG17lmwf/wPqwDCjpQ0CcNF3Ux5A7i/zlWPbm3J/0xb2vvrcL3JN2hu
+A+DbL27bbNTwHwFDQm72MUuN+yEedwIDAQABAoICAAuYKlwwvv16vfve8pe6uEgY
+KOoj6+lj7qkv4raeU97OkBuOzyv9VtaqMQBGq8NBVPLNlluoUofO0x8EjBejlpN5
+nAkKCtOe3ZCdWyee+dS7yj5c23C5z/Kf3ayce9qUJOpHXB84WRfGz/2XwOK5c2qC
+y+C9et4L96YhEAqAvgP0hvf+40vSxDM4nGpYNDWdiR8H0FGW5nMlWXLPKI3cKQE8
+m6eU8+jPVdjjCQv1rNisipyubkAL0aaWVFQUE5CWvdHxHbtQABygqyshLaew6XmV
+MKwaz95eC97jsU6J28RnmJ7GjUlZJreHpwyTLCMsMqZ3ZJ/wVdw1zFmflEH1SgPq
+/JNd0OONKm8x7nORX9dHEn33Imfyg2jI6tzVx1oAmMWMb9hJ0XjkIyzjfHTPi5KW
+pM3pTUUn6ee4P1T4ReBlatiw2TFgAd18/9gSIaSlENEjslJGQ6/Ndt9O7UNHgwth
+ZNtPovjNLqUobHGXlmwg3haeBshn9iPcjdksAjgtjEyowzq7IpiSxQezXNcMezGM
+Y9UL5Qc/yjQ3t+Vu94Jmnu0TT3lHGWa3zSgI6L+UdBiIsLF6P5YQVloYOYWE3q/n
+HTaORoZlsRKfMIUHmhrZ1keJ4VGqLruSpQHobh3Cfb/xzgOEB3nSwhIK3l2FhSiR
+N9jb0r7kMElO+xlm7NChAoIBAQDllnlfyWnTBGog8+T9eJiODuBfdozy2vCZO8nc
+vp11NC7fLh5NXR16Ju6I+dcXDhPdoOG8H/DScjer82kEINrY7Wb4swNd01cLCg+/
+xVNe9iiLl4Q4m/QOI6ZOUbOfJjH9R8J4Bh/FzR1MXtVktgtsd6JB3zv6V246zDjy
+eMnOImwoj6TH/3hI/g2s5i3GoaC7CK+XjpdfZbVAX5+mnpZxBbOqXt7an1IzYHhx
+hQO8uo/9b2IDxMrWWn80mGj9Fw5AdK1Ef3eMtbyG6iOIR92UEo9ZwlZ9Tang58Sa
+7IFHZko/HcCrS92Hl9YcnYmjG0GDeFl4des+IcVz0AHDhe6RAoIBAQDIolXgCYO3
+zo2MtoBTCr+GcluT4DD16ALz7wd8/jXFqmD3UWCAeaS5IsTno1PmuIpvB7dvwz8B
+6SOpE//J/bECDmhE18UHYOAqkXzzuuEGMCP1TuaCWBq7kWV8GVTRcSGQDxLyf/Yu
+IdxiPQMaCxi0Ffv+aq27Nii1IyV8tyDL3skyGZeQJNW2xjNkngkXsB5Tp7H7tA0G
+lSmld1Rtq2XWcRnHQh9ZVP+FxwkjBkdoX0oAASVQwHsy9Q4hZ5ykxPkIGULj3Hw5
+zvG1RAM5B4GQegK0OfYuX5Ullrz6a/6p/FnGLvRkZGlHML/bHTmrr8ywSvF63Gkd
+oU0nqjPFQ1CHAoIBACoFR4PDno3TwgTz/tZxqyJdEK4ISbXtYpn5OnIfpTwdZ/LL
+QxqPz2RbGc+SQs7icbpfxtEi23X5F71uGKt7w/JuSSl9wkD6/HR1y/oiiKbZ0QPz
+oGyoBpxL5BVzmLepSv77kllbbZdLenBO7ym2tBKPNvBthlHEjNVQKaAfgXgsDrXB
+zLwaQw7BCQm7O2eej4eMCG9p1sTMHceBePwLDKf1DjRBlvJWtLnYj1LfsJZrYw1U
+xJDCBQoEmEGtH5IrFR2w/UGLPvtPDAl5czVvSdvfJcOc8S2P+GbEpNRiMys5Sp+Q
+t4HiqdI2dSbZoqZqx6vjbCTDGGJP1g7jZF8/9TECggEAXOXVj2O4an4oSnQiXNEI
+N29x+bl/0gy4eUw/El/+c+Tc+wbiAPrSC6sOsxaL/bOK3bgb9pLX9MGHcn1BHbzq
+ncIgA2hI4Y64nN06lvv7v0rBC4+Z6dZzok/DRr/P5x5T5Qklw8T+LwQcsBwB+KgU
+qyXWxUmN4bZFCQIaFHISrHMeg6UX6XU0w2loWHlYSnCQyjlGjv4iXd7pJqVnIVSQ
+VceOoRV7wHg7zCyJjX8Vxzz/3ZqqNYa6RLD09wCrphtSF67iqvDnUDkC7+Rq/Zf9
+JPFpmRuRYo19WKdAH0+r3fdrdfk9zdI0cPMgkosordc7lpFM2I9/2GlceTY0vGzb
+twKCAQEArUbkiwUZFjdjAbKS2m0uPJyytB8bZ335szcoMUV665hzU9EJPcWeVY0L
+1FSRu/cig+ZCmpUEc/4JhJVKLEEXgC3BgfHGNHi5PIuvssMT/fJJ9InQe8n4Zq0Q
+eZbrfAewrdH3bTpEf6AxIsrMioLsUQSV12iRQ7olsEP9t5HqRKqwhAnqp+q33XT3
+L++8IcaaEQ3S/sBb23pY+VSWQfKGFVQES+P7yKeNHjBNQpJTPOdM9iLtvriUmNdO
+Gy5HOpLgd10DzXBOI7CgqzFm69Bqk+WFZXGVd9T/Ku69B8XfshoRChGbgHbbEG70
+0xT4AQEuygYVBbUrIerZFpDD+Tw7ww==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.3.18-alpine-3.5/openvpn/firewall.sh
+++ b/variants/2.3.18-alpine-3.5/openvpn/firewall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# This iptables script to controlling traffic in the openvpn tunnel.
+# In this example, clients can only perform DNS, HTTP and HTTPS requests to the world.
+
+# Drop everything by default from tunnel to world
+iptables -P FORWARD DROP
+# Allow DNS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p udp -m udp --dport 53 -m conntrack --ctstate NEW -j ACCEPT
+# Allow HTTP and HTTPS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p tcp -m tcp -m conntrack --ctstate NEW -m multiport --dports 80,443 -j ACCEPT

--- a/variants/2.3.18-alpine-3.5/openvpn/server.conf
+++ b/variants/2.3.18-alpine-3.5/openvpn/server.conf
@@ -1,0 +1,280 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/server.conf
+port 1194
+proto udp
+dev tun
+server 10.8.0.0 255.255.255.0
+ifconfig-pool-persist tun-ipp.txt
+;client-config-dir ccd
+keepalive 10 120
+comp-lzo no
+max-clients 5
+user nobody
+group nogroup
+persist-key
+persist-tun
+status tun.status
+status-version 3
+;log-append server.log
+verb 4
+mute 20
+;duplicate-cn
+tls-version-min 1.2
+cipher AES-256-CBC
+auth SHA512
+key-direction 0
+;crl-verify crl.pem
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            97:80:c6:6b:b5:84:81:b3:2b:f6:56:55:da:67:4d:c8
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=server
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:be:f7:ee:15:bc:b6:e1:04:28:3e:38:6a:61:dd:
+                    ee:fa:61:85:9a:a7:be:44:22:52:b4:cf:7a:86:0e:
+                    21:ae:1e:2b:61:66:17:1f:54:dc:e9:75:27:55:24:
+                    39:fc:ee:92:d1:da:de:e2:5f:01:50:b6:ae:52:1a:
+                    79:6b:8d:56:0d:83:f6:d4:19:50:48:bc:cb:d8:69:
+                    c8:79:d4:ba:82:05:db:aa:58:12:4b:34:1b:15:d1:
+                    28:2d:b7:08:4e:a0:64:fb:c6:b4:e2:8b:61:68:4e:
+                    72:72:cc:da:a2:d8:cb:f5:6a:5d:13:b6:98:d3:0c:
+                    a3:05:7a:21:e3:f9:fb:de:89:be:37:ac:ce:4c:2e:
+                    95:98:9e:48:3c:04:97:cd:a3:36:92:15:12:a4:bf:
+                    46:ea:95:37:0c:6f:09:e1:51:f5:4e:13:9f:f5:68:
+                    65:0e:24:38:62:04:f8:f9:0c:06:72:c9:03:ed:5d:
+                    6f:40:3b:62:ea:a2:79:01:79:d0:58:aa:2c:7f:89:
+                    14:bc:3e:86:c0:5e:58:ac:58:c0:97:fe:65:57:46:
+                    bf:01:cc:d4:d7:64:d8:21:15:02:6b:6a:38:24:bb:
+                    2b:45:c7:79:23:7a:7f:0c:6b:25:d3:ce:e1:3f:e8:
+                    68:6c:31:7a:df:88:49:6d:a3:7e:22:24:08:3d:e1:
+                    6c:87:dd:34:77:d2:a5:eb:f7:e6:74:b9:e2:5f:e4:
+                    ad:49:e1:c0:b4:8f:d9:b5:ac:2d:7b:ba:22:64:8e:
+                    b7:c1:11:11:f1:e1:1f:b9:3e:29:b1:61:9b:8a:1c:
+                    2e:d4:e4:e6:10:5a:5d:e1:f9:1e:54:7b:13:79:dd:
+                    d9:ad:8b:23:c4:8d:a5:8b:f5:17:eb:99:96:5d:c6:
+                    8d:b4:af:8b:4c:2f:08:4d:37:c3:bf:6d:68:99:c4:
+                    f7:47:cc:5d:44:e7:6e:f2:64:b3:7d:bb:9b:c7:e1:
+                    27:cf:73:8d:b2:e2:88:19:6c:bb:6e:cd:4a:0a:79:
+                    a8:7b:9d:c3:b0:59:93:51:20:a1:d8:a2:0f:e5:62:
+                    76:17:b3:bb:aa:bc:3a:73:e7:f6:57:91:6a:cb:d3:
+                    7e:91:38:5e:88:57:e3:d8:3e:31:cd:dc:69:9a:74:
+                    bb:6e:62:c2:ab:5b:8c:f5:80:ff:b4:98:a2:87:15:
+                    72:38:77:76:dc:e2:d1:ac:2f:66:67:ae:c4:33:a8:
+                    86:94:af:41:b1:99:0d:5d:68:df:9a:ec:86:0f:0a:
+                    c9:67:fa:a1:7c:29:47:d3:f1:c1:3d:8a:d1:a4:12:
+                    a6:70:16:37:80:4f:d9:79:61:45:1c:07:77:68:60:
+                    4e:10:ec:94:dd:03:95:b1:37:cc:88:3d:60:cc:32:
+                    37:be:a5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                4A:91:C2:3E:A1:E9:04:C9:C0:9A:8B:CE:D4:37:4D:96:0E:74:FE:90
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication
+            X509v3 Key Usage:
+                Digital Signature, Key Encipherment
+            X509v3 Subject Alternative Name:
+                DNS:server
+    Signature Algorithm: sha256WithRSAEncryption
+         72:b4:75:02:f7:7b:e9:07:c6:79:1b:bb:11:e4:73:4a:b4:76:
+         1c:03:b9:58:8c:0a:80:f0:c6:8c:cc:2a:a7:c7:8c:57:a8:6e:
+         52:19:f0:b5:7c:0f:06:ab:2f:04:0e:99:32:b9:2c:b6:42:f0:
+         f5:5b:97:32:ce:bb:0c:ee:9f:b0:0b:bc:0b:c0:43:1d:7d:04:
+         b4:a1:cf:a0:aa:fe:f1:cc:b4:31:b3:bb:78:ed:0e:60:8d:37:
+         ea:48:a7:b4:2d:6d:64:6e:97:15:aa:e4:9b:b4:68:79:c8:3b:
+         ba:91:0b:db:cd:04:a3:aa:e4:69:59:06:ec:50:68:6d:0d:a6:
+         38:32:55:76:09:10:00:da:ac:a8:9e:ad:ad:95:8f:01:88:c9:
+         40:af:9a:5c:2d:17:34:81:6b:26:65:8a:e5:2a:15:79:13:2d:
+         ae:d8:03:16:6b:e9:b6:cd:f3:cb:d5:4d:5f:40:76:7a:99:99:
+         d5:2f:e8:a1:59:88:01:6b:a1:36:c0:53:dc:46:07:fd:ab:ab:
+         2a:5b:d3:d5:4c:84:c2:fb:48:16:80:80:01:f6:37:80:3a:54:
+         81:11:24:86:a6:a2:9a:73:06:5f:ca:24:8c:20:3a:40:6e:95:
+         8e:44:46:ef:60:bc:9d:11:ad:71:af:61:85:a6:e2:b4:49:c7:
+         fa:bb:ef:b5:c9:02:d2:a2:a5:3b:f6:46:03:dc:58:9f:ff:dc:
+         23:6b:b5:02:4c:1a:1a:80:99:6d:1a:fd:24:fc:32:83:f7:de:
+         fd:2b:b2:45:b7:3b:89:3c:49:0c:3d:0b:05:67:a5:95:00:3d:
+         cd:a7:0a:3b:b5:cd:02:10:09:de:ff:6c:6b:8b:aa:9d:e6:e9:
+         07:83:e2:dd:de:6d:bc:9e:fd:19:77:30:5d:67:12:c2:33:40:
+         0f:13:69:98:02:ef:05:b2:ad:ef:fb:73:15:57:70:46:83:32:
+         a9:05:4d:31:06:3d:44:93:88:69:de:9a:67:b4:6b:b7:0d:6b:
+         69:24:8b:62:52:f7:85:66:8f:84:2d:c0:a7:ff:33:37:7c:f3:
+         d1:1f:8c:b6:16:a3:98:db:6e:aa:e5:eb:d8:ed:06:31:19:ba:
+         01:f1:e6:3e:bc:78:ec:6e:b4:af:6c:8a:49:0f:ff:5a:f0:00:
+         88:d8:66:af:d6:49:31:b5:54:ce:be:07:59:46:bb:67:73:4b:
+         b8:ec:be:16:04:ed:fe:75:57:21:d6:d5:7b:cc:d0:7c:bd:91:
+         d3:6e:61:72:04:30:24:45:0a:0d:16:b6:35:94:49:02:14:8d:
+         2d:1d:71:42:13:9a:02:1e:3c:31:05:b4:76:5b:dd:ff:bb:db:
+         f4:31:b7:47:bb:54:f8:27
+-----BEGIN CERTIFICATE-----
+MIIFYjCCA0qgAwIBAgIRAJeAxmu1hIGzK/ZWVdpnTcgwDQYJKoZIhvcNAQELBQAw
+EzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMjUxMDAyMTE0
+NTEyWjARMQ8wDQYDVQQDDAZzZXJ2ZXIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+ggIKAoICAQC+9+4VvLbhBCg+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzp
+dSdVJDn87pLR2t7iXwFQtq5SGnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV
+0SgttwhOoGT7xrTii2FoTnJyzNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWY
+nkg8BJfNozaSFRKkv0bqlTcMbwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2Lq
+onkBedBYqix/iRS8PobAXlisWMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8M
+ayXTzuE/6GhsMXrfiElto34iJAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17
+uiJkjrfBERHx4R+5PimxYZuKHC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZd
+xo20r4tMLwhNN8O/bWiZxPdHzF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7
+ncOwWZNRIKHYog/lYnYXs7uqvDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKr
+W4z1gP+0mKKHFXI4d3bc4tGsL2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT
+8cE9itGkEqZwFjeAT9l5YUUcB3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABo4Gy
+MIGvMAkGA1UdEwQCMAAwHQYDVR0OBBYEFEqRwj6h6QTJwJqLztQ3TZYOdP6QME4G
+A1UdIwRHMEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhD
+aGFuZ2VNZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwEwYDVR0lBAwwCgYIKwYBBQUH
+AwEwCwYDVR0PBAQDAgWgMBEGA1UdEQQKMAiCBnNlcnZlcjANBgkqhkiG9w0BAQsF
+AAOCAgEAcrR1Avd76QfGeRu7EeRzSrR2HAO5WIwKgPDGjMwqp8eMV6huUhnwtXwP
+BqsvBA6ZMrkstkLw9VuXMs67DO6fsAu8C8BDHX0EtKHPoKr+8cy0MbO7eO0OYI03
+6kintC1tZG6XFarkm7Roecg7upEL280Eo6rkaVkG7FBobQ2mODJVdgkQANqsqJ6t
+rZWPAYjJQK+aXC0XNIFrJmWK5SoVeRMtrtgDFmvpts3zy9VNX0B2epmZ1S/ooVmI
+AWuhNsBT3EYH/aurKlvT1UyEwvtIFoCAAfY3gDpUgREkhqaimnMGX8okjCA6QG6V
+jkRG72C8nRGtca9hhabitEnH+rvvtckC0qKlO/ZGA9xYn//cI2u1AkwaGoCZbRr9
+JPwyg/fe/SuyRbc7iTxJDD0LBWellQA9zacKO7XNAhAJ3v9sa4uqnebpB4Pi3d5t
+vJ79GXcwXWcSwjNADxNpmALvBbKt7/tzFVdwRoMyqQVNMQY9RJOIad6aZ7Rrtw1r
+aSSLYlL3hWaPhC3Ap/8zN3zz0R+MthajmNtuquXr2O0GMRm6AfHmPrx47G60r2yK
+SQ//WvAAiNhmr9ZJMbVUzr4HWUa7Z3NLuOy+FgTt/nVXIdbVe8zQfL2R025hcgQw
+JEUKDRa2NZRJAhSNLR1xQhOaAh48MQW0dlvd/7vb9DG3R7tU+Cc=
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQC+9+4VvLbhBCg+
+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzpdSdVJDn87pLR2t7iXwFQtq5S
+GnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV0SgttwhOoGT7xrTii2FoTnJy
+zNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWYnkg8BJfNozaSFRKkv0bqlTcM
+bwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2LqonkBedBYqix/iRS8PobAXlis
+WMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8MayXTzuE/6GhsMXrfiElto34i
+JAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17uiJkjrfBERHx4R+5PimxYZuK
+HC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZdxo20r4tMLwhNN8O/bWiZxPdH
+zF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7ncOwWZNRIKHYog/lYnYXs7uq
+vDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKrW4z1gP+0mKKHFXI4d3bc4tGs
+L2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT8cE9itGkEqZwFjeAT9l5YUUc
+B3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABAoICAAnfT1OYWevwBxSQXg+JJZ2U
+BRAls9RZ4eSvBSqA+ITD0oJKgM+B15nKEKp6IPVOcBChO/x/5NWDXCeqbrR8rgIs
+3EnCtT/NYsxhS5fgw3ONUfnQa8Gvg+bw1R7n42oNKKtLbnZ3tiVqSMhehr78bi7V
+vNIUEnp2oMbbtXzPo5GxlT/TkyalEd698AYKRr6+vUd4B2q06Lmf1SSzaNNZJVFP
++mj5aJ/+h1up3iUh1gOBGM7gkavEZiyzEYZeAcNTqNE/CO9iXBz9w5/FRs+UuzBz
+29P//tDTyciMCX/8EcL0WhxVX5HR91dxApecjlB7d0qAlFWR+hnM5exl6HcqfC3C
++Uhi5IC+gZjD2KCcHDr9e5WqQ6cu8TeMnoyuHInIV9kUL3Bn1ArOU1dmGS78soeE
+GpqGCRc9Imh8jxs1AVyj9wGzpfuRS8OBpfR5MIlcFwSlZO/6dnJSaF2BH1jnKgBG
+Xn9MvjfHTU/EhLTteXrAJlqQr4e/uAK5QCESFNXLvC0r3qord6b9Y0zHR63SpESJ
+WVUIF9L2fIh0Z4CutPegcbEyWLaaAT4njyR4uCI78g77kK+PGi2NM65Mk+wKt975
+m3Qh4/cNv1ews4h+RflayWC9kiiRVzDHJGTy63k5gdplqrW2rb8gK3ZQaT2gQp9u
+gjKIIFGyi+EIDSukHNdRAoIBAQDuGvE9k1lSvoPgSusogMk7PWTiZbn8MwlEFueM
+ZJk9k8dMSkqF1k5BXG9lHcWuFl2invgTiFJIF7ML0GDsFJR+CzCDsanSGdjyKfGM
+HzHAc7UPAJYBXPX1rxTAhGSirKjArcqYUX3ZGGaTo1yZrsbbarInUhWWNKFBdaQ+
++L3oClGt3GZx7hdxapI/3gnkLvG/C5hWWetLONZAxY6jwJJSA/p2Fx93SlWOtrmT
+KRbM/p8m6sHtsXcBnYTueqWYpJ2mnBIB+Svf5acqQ2Xf8kAIw4Vw9u7a15OlIDGF
+ouWhtSkL4s0YfZjlXswOPZDlF3eT2ilf+OIjv5kEcLdDKOojAoIBAQDNUhfys2TH
+b1NFsIH6X1jtWHUEGOYIM/y/75Vw2pGLb40cMxVPtzsNCvz8id/sCuvx6yUWlBlN
+wjpa+7dOA+FgoXwv1iVsQm1zQlrt2VKaEy29C0tRkSwOjNC0bz1409wzYNnh5Bdx
+KJDvSz9zlefAryJGTSgGOothOjnguzoEJ6DxfkxNyWbxceBgN8JljDhc9dcybKdD
+Uxy2GflXhZvZfCtTbYfWoIV+dTYyZt2QE4PEPXrJHGUFE9ncGynbzAn1Cc/zGBeT
+zFNoYOCWNr7ueRNHQYMRZ1N3dYRdZ9th5mdqqa1eY5lP4PyQYZV6lwmyEfitXwNz
+vhS0sO+pNAyXAoIBAB9OiZOoESGRDTPrhdnwfQT+AIrIB1lCuKAsRsut2nw/NwAv
+8HaChA2SAs+Px5MpO6yLLGEdFnyGKTOPdX71AcVE4V8feA24+k50916OJ3N/gzny
+wMZzG5/vIlJh1f2RqCqVb0LxzBNEYxBcdWt7kIf/EmebIl16lA1QU4U4HXgqCy1K
+AmpOfOSbt5kQL8rB5WVSN/h6oDZmxb0EfMnJIzQHc+IdDjUYIAHAwsu3pljTzcdH
+LLJ9GAGtXXIhzC4yzsu+T5vU0FEDGCS1ceqtJoBAfQYqYaOCntYiUoCYt4q4kCoQ
+6xiiQv09pqTksW191WoqUDBfQBSlN5Be5am98nMCggEAIzEb+7R15J0XN82uKZzo
+IB5WSDKAUw2eF8PX6HT+F1kyZY/36ibszyp//EUhhVLF6Dw2qi0OPT66Q9f7LjsK
+CUcEgyqAVZL5MZVBAp2KQ/BfmZRy/3MTixbluteKQMiHaKMEFWzD+9hJJ0rNgGFE
+TMl35XbaEl88fpi9TOCqbAXi1yGfsIGBzIaJP9Su1Dr5ei2FChaHgMmhFTFUhITZ
+FqjqwCz46HexCeDLPk5VUZmWry8eeZQNWJZzc/+P6CWL210oMHGDsQiHj09zjyup
+BDTqcf8vmO8N5l7VJjFj797PAQA+P/xwTbmxcInZVh7HQadE6WpsrAz7fZEKMwVB
+1wKCAQEA3oqXI9bGGoXFjydUiNMZbuHdIDQCa9t7iDb+J+NAiA7GI8W8DlFYrUST
+S/CoBey/WOW9jPT/A8EBnp8RmPtAJH88qklbqh/YCoKyKZrgqT5IGysRLWwDFrGT
+QoOvR1a6SaVMLskmYUCkl8Yz8sZS58X50ahxx5TB0I3xsoCmnMZt+cd2C/VXwhFz
+jCiEZIuQlSgQFW4LOFrxrXmI+MDOBWu4zvkztWOnTe+BNgrxndGVI6sdFGzWeNQx
+dQ9imn0UqGSkgnJEj7Lq67ey8Cuu6yYWexKI0N9UOcyL4FgaEdWiJ0t5KY6NElGI
+0jrZX7pwVf/pvbKW2zVm6nXjWJ/JFw==
+-----END PRIVATE KEY-----
+</key>
+<dh>
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEAqJI9Luwkfy0E95gqZyq031Fa1rUCW5aBoppgm4YHxGUL+fUQzveF
+U2+W5xzmZuxhyoN0PVqlPXoMi0xGyTW4ga8qMaIHDqQ/V8RNxQYJ+GEEiC46/2u9
+Co/HbGX9YXMm5nnNEtHepAHcJiRB6QbCjzVm06x5QfWifj/yTm9ycVfJXhQJiOkD
+j4y4vJbgrmIKWX8Nxj4Q8dCAJzZ2gFvMnW9XcbS9SYbyvS0DvoQG3gPTGcopv7x1
+NiOhrxcTcMjwi/2z6kxG0MJEZ1HOJ2xTtRReUGXkL0lhbVTzkX4V6ihWK4MZYqe+
+ozy/0gbPAB4dT1QNeSRXPOi9f81Oed0SoC83P0oiq3JRQq2g7aS9OiwqlRPnVnvH
+q7Uko6+nv8XLbANgbdLXc8I3K78TSedwofxI/atxKncEic0fHV5ai2IdEWt22qxj
+iWVyaiHlWtMosZvuepSPn3cAmfuj0dVPNiRoG97neN8XIOaVZNGmNnI4yM0JEA1h
+Ef4Lh4YpDdqk4Q/nC/zJev8PM1XC+Os1SsGH50YAn8q19TGzI26/Y4jWfqrHswsj
+6vF/lxDS5RRzLIqlEksm84MU1q0AFSe9FaW1NTtKR/PLO1QiSKr718BwzzrDNN9u
+KZJabQ9n1RgLSuMP9zk9A6GUPQ7cZ0fJchUPeuF8Cd7zAV7k4m0RA4MCAQI=
+-----END DH PARAMETERS-----
+</dh>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.4.11-alpine-3.10/Dockerfile
+++ b/variants/2.4.11-alpine-3.10/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.10
+
+RUN apk add --no-cache openvpn~=2.4.11 iptables
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/2.4.11-alpine-3.10/docker-compose.yml
+++ b/variants/2.4.11-alpine-3.10/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '2.1'
+services:
+  openvpn-server:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
+      - NAT_MASQUERADE=1
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/server.conf:/etc/openvpn/server.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    ports:
+      - 1194:1194/udp
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped

--- a/variants/2.4.11-alpine-3.10/docker-entrypoint.sh
+++ b/variants/2.4.11-alpine-3.10/docker-entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+# Env vars
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
+OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
+NAT=${NAT:-1}
+NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
+CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    echo "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
+
+# If no args are passed, run the entrypoint. If a flag is passed, run openvpn directly. Else, run the passed command
+if [ "$#" -eq 0 ]; then
+    # Provision
+    echo "Provisioning tun device"
+    mkdir -p /dev/net
+    if [ ! -c /dev/net/tun ]; then
+        mknod /dev/net/tun c 10 200
+    fi
+    if [ -f "$CUSTOM_FIREWALL_SCRIPT" ]; then
+        echo "Executing custom firewall script: $CUSTOM_FIREWALL_SCRIPT"
+        . "$CUSTOM_FIREWALL_SCRIPT"
+    else
+        echo "Not executing custom firewall script $CUSTOM_FIREWALL_SCRIPT because it does not exist"
+    fi
+    if [ "$NAT" = 1 ]; then
+        echo "NAT is enabled"
+        echo "Provisioning NAT iptables rules"
+        echo "NAT_INTERFACE: $NAT_INTERFACE"
+        if [ "$NAT_MASQUERADE" = 1 ]; then
+            echo "NAT_MASQUERADE is enabled"
+            iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+            if [ -n "$OPENVPN_ROUTES" ]; then
+                echo "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+                for r in $OPENVPN_ROUTES; do
+                    iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+                done
+            else
+                echo "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+            fi
+        else
+            echo "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
+        fi
+    else
+        echo "NAT is disabled."
+        echo "Not adding NAT iptables rules"
+    fi
+
+    echo "Listing iptables rules:"
+    iptables -L -nv
+    echo "Listing iptables NAT rules:"
+    iptables -L -nv -t nat
+
+    # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
+    set openvpn --cd /etc/openvpn --config "$OPENVPN_CONFIG_FILE"
+    echo "openvpn command line: $@"
+    exec "$@"
+elif [ "$#" -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    echo "openvpn command line: $@"
+    exec openvpn "$@"
+fi
+
+exec "$@"

--- a/variants/2.4.11-alpine-3.10/openvpn/client.conf
+++ b/variants/2.4.11-alpine-3.10/openvpn/client.conf
@@ -1,0 +1,258 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/client.conf
+client
+dev tun
+proto udp
+remote openvpn-server 1194
+remote-random
+# Push all traffic into the tunnel
+;redirect-gateway def1 bypass-dhcp
+resolv-retry infinite
+nobind
+user nobody
+group nobody
+persist-key
+persist-tun
+remote-cert-tls server
+cipher AES-256-CBC
+auth SHA512
+comp-lzo
+verb 4
+key-direction 1
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:4e:3e:ee:0c:a0:be:17:77:36:7e:3e:48:bf:5a:f3
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=client-01
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:b3:ef:25:0f:86:77:8e:9f:a4:42:02:f0:19:0e:
+                    20:0e:93:5e:67:78:17:99:a9:cd:06:84:fe:c1:ed:
+                    5b:c9:96:d1:82:ef:5f:a5:95:d7:de:99:97:84:cc:
+                    a8:28:13:69:2f:41:7a:d4:f0:ac:a7:a3:10:8a:31:
+                    c6:aa:14:dd:d0:5d:15:51:2c:e9:5e:3e:fe:f0:1c:
+                    d7:62:07:f7:fb:01:93:22:8f:4b:72:77:76:8a:14:
+                    fe:26:52:59:c8:59:b0:01:b6:cb:7a:2d:ba:0d:35:
+                    a2:8c:42:97:18:54:45:58:f1:69:ff:3b:ce:fd:71:
+                    a5:13:42:82:ca:e2:25:43:61:d6:34:1f:f6:f3:36:
+                    7f:c9:7d:a4:e2:83:f1:8f:b7:2d:cd:7f:cf:1a:90:
+                    a4:86:ce:c0:6b:36:b3:9e:90:d0:60:5c:ec:ac:70:
+                    f7:32:16:59:20:1f:27:a5:3c:00:a0:9b:63:30:41:
+                    a5:d3:63:37:9d:10:f7:f6:53:45:54:57:70:7e:06:
+                    a6:01:32:38:2c:2d:d1:11:4c:3f:57:25:5a:2c:2c:
+                    06:a0:20:bb:c0:95:fd:44:a8:0d:3a:b0:c9:a3:b2:
+                    77:ce:f7:f0:f5:c8:1c:a7:74:ba:b9:83:0b:3c:56:
+                    6f:18:cb:df:39:77:3a:69:18:57:be:48:7e:ab:2a:
+                    21:2d:b0:eb:4c:26:ae:93:f2:d9:0d:29:01:b8:2c:
+                    0b:5a:ec:8a:c0:fd:5d:1c:a7:6f:31:29:5d:5c:35:
+                    cd:0e:e0:97:86:07:af:5e:69:8e:e7:e1:f0:78:21:
+                    f3:15:c6:35:cd:e6:4b:65:d5:17:0b:87:6e:ea:39:
+                    44:96:ab:bc:fc:ee:27:85:fe:10:c4:77:96:25:cd:
+                    9a:66:ee:e4:36:fb:f0:c8:90:62:de:6d:f6:8c:19:
+                    76:c6:6d:c3:9c:a4:9f:80:ec:39:79:ba:32:36:b2:
+                    7d:93:3c:dc:58:c5:13:34:35:8a:7e:cb:cc:f0:9a:
+                    bb:39:dd:ca:bc:cf:c7:7a:8f:9b:60:f1:a8:e6:e4:
+                    41:62:82:cd:cc:d2:81:06:c1:5b:82:0c:49:88:e6:
+                    bd:39:b2:06:82:a0:fb:55:ba:fd:de:57:2f:40:84:
+                    07:b8:38:9a:49:6e:38:49:c0:b9:26:f7:7e:a9:9a:
+                    18:b3:27:b9:d9:b3:fb:7f:6d:9e:68:58:94:f7:b1:
+                    21:b5:ee:59:b0:7f:fc:0f:ab:00:c2:8e:94:34:09:
+                    c3:45:dd:4c:79:03:b8:bf:ce:55:8f:6e:6d:c9:ff:
+                    4c:5b:da:fb:eb:70:bd:c9:37:68:6e:03:e0:db:2f:
+                    6e:db:6c:d4:f0:1f:01:43:42:6e:f6:31:4b:8d:fb:
+                    21:1e:77
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                23:46:34:1C:74:3B:D8:21:40:4D:81:B3:58:9F:57:CB:0C:5E:90:FB
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+    Signature Algorithm: sha256WithRSAEncryption
+         3c:80:ef:a8:a1:94:bc:12:33:6c:19:2e:44:44:6c:20:8e:69:
+         f6:b8:21:ad:4b:f7:14:d6:bf:c3:8d:b0:87:d1:e2:55:df:c0:
+         fd:03:31:82:8a:82:dd:68:3d:61:1f:c4:89:eb:e6:07:b0:89:
+         1d:19:8b:ee:57:9f:87:d8:a2:d8:fe:84:ad:f1:18:9c:b5:93:
+         a1:17:48:41:1e:f7:12:1e:50:46:b7:57:93:6e:d5:0f:d5:84:
+         a8:8e:74:4f:ab:8a:ae:40:64:8a:a8:57:32:75:b6:82:20:10:
+         be:ab:70:0c:96:c7:30:f4:69:c7:c9:24:db:3a:bc:40:eb:ac:
+         ee:04:f3:58:4a:09:6e:42:01:b4:a5:77:e5:2b:01:05:c1:5c:
+         08:59:0b:e3:a9:7a:b4:3e:f9:41:8d:2b:e6:8e:40:27:07:07:
+         0d:b0:03:ba:c9:d2:cd:dd:3c:9a:7e:20:66:bb:7f:4f:9d:fc:
+         37:16:88:84:a1:26:6a:91:43:d1:47:82:cb:e1:84:d4:03:93:
+         ec:8d:14:ce:2c:c8:fc:96:f8:28:d5:cb:89:c8:84:ee:8a:54:
+         8e:3c:12:86:10:73:78:5c:b8:a5:7d:99:94:b1:e1:f9:18:ed:
+         4b:2f:ae:8d:d4:9b:bc:20:21:d3:13:ed:07:15:70:dc:d1:1f:
+         58:22:fc:0e:5a:49:4e:6f:c1:99:9d:de:71:4e:62:7d:ad:d3:
+         2e:c3:ca:3f:db:cf:f3:46:aa:95:1f:99:1c:81:f8:15:5a:a1:
+         30:f7:7b:4a:e1:8a:fa:8b:a4:92:6d:11:e3:4c:f5:2b:b9:a3:
+         6d:a4:07:93:cb:28:f7:06:c1:e8:1b:1e:c5:aa:76:51:7e:1b:
+         a7:fe:db:9b:d4:23:d1:2a:16:52:ed:d1:2c:55:2b:cd:db:73:
+         fa:20:1a:18:47:af:90:50:0c:fe:1b:0d:f6:06:ec:33:1f:8e:
+         6f:f2:9a:d0:49:88:cb:a0:8c:8a:60:54:8e:d0:c1:59:ad:e6:
+         6e:6a:3e:e4:3b:b4:1b:01:8e:81:a4:f2:21:94:d1:a7:5e:e8:
+         1a:14:af:f1:46:5d:6a:ad:9d:06:02:84:58:96:b2:e6:f8:02:
+         5f:ce:ed:87:54:b5:f9:b6:62:97:51:b2:88:05:49:de:fd:56:
+         d1:67:e5:59:78:31:82:36:17:ce:07:62:81:5c:19:82:48:22:
+         88:15:ea:d9:fc:1e:c3:ee:05:a5:ec:e9:ca:69:b5:2a:7e:79:
+         ed:aa:6e:3f:b5:45:75:0b:d4:27:e4:4c:88:04:e0:06:36:5e:
+         41:37:b0:f5:44:80:58:86:dc:c1:be:82:62:fe:a8:2c:6c:ca:
+         6a:f8:dd:fd:85:df:5a:41
+-----BEGIN CERTIFICATE-----
+MIIFUTCCAzmgAwIBAgIQDU4+7gygvhd3Nn4+SL9a8zANBgkqhkiG9w0BAQsFADAT
+MREwDwYDVQQDDAhDaGFuZ2VNZTAeFw0yMzA2MzAxMTQ1MTJaFw0yNTEwMDIxMTQ1
+MTJaMBQxEjAQBgNVBAMMCWNsaWVudC0wMTCCAiIwDQYJKoZIhvcNAQEBBQADggIP
+ADCCAgoCggIBALPvJQ+Gd46fpEIC8BkOIA6TXmd4F5mpzQaE/sHtW8mW0YLvX6WV
+196Zl4TMqCgTaS9BetTwrKejEIoxxqoU3dBdFVEs6V4+/vAc12IH9/sBkyKPS3J3
+dooU/iZSWchZsAG2y3otug01ooxClxhURVjxaf87zv1xpRNCgsriJUNh1jQf9vM2
+f8l9pOKD8Y+3Lc1/zxqQpIbOwGs2s56Q0GBc7Kxw9zIWWSAfJ6U8AKCbYzBBpdNj
+N50Q9/ZTRVRXcH4GpgEyOCwt0RFMP1clWiwsBqAgu8CV/USoDTqwyaOyd8738PXI
+HKd0urmDCzxWbxjL3zl3OmkYV75IfqsqIS2w60wmrpPy2Q0pAbgsC1rsisD9XRyn
+bzEpXVw1zQ7gl4YHr15pjufh8Hgh8xXGNc3mS2XVFwuHbuo5RJarvPzuJ4X+EMR3
+liXNmmbu5Db78MiQYt5t9owZdsZtw5ykn4DsOXm6MjayfZM83FjFEzQ1in7LzPCa
+uzndyrzPx3qPm2DxqObkQWKCzczSgQbBW4IMSYjmvTmyBoKg+1W6/d5XL0CEB7g4
+mkluOEnAuSb3fqmaGLMnudmz+39tnmhYlPexIbXuWbB//A+rAMKOlDQJw0XdTHkD
+uL/OVY9ubcn/TFva++twvck3aG4D4Nsvbtts1PAfAUNCbvYxS437IR53AgMBAAGj
+gZ8wgZwwCQYDVR0TBAIwADAdBgNVHQ4EFgQUI0Y0HHQ72CFATYGzWJ9XywxekPsw
+TgYDVR0jBEcwRYAUmBuw7bvaYZi1OnrIxE4ycKX4qQehF6QVMBMxETAPBgNVBAMM
+CENoYW5nZU1lghQRFLv/ZzUIweAY3+3bxHLwDm1FLDATBgNVHSUEDDAKBggrBgEF
+BQcDAjALBgNVHQ8EBAMCB4AwDQYJKoZIhvcNAQELBQADggIBADyA76ihlLwSM2wZ
+LkREbCCOafa4Ia1L9xTWv8ONsIfR4lXfwP0DMYKKgt1oPWEfxInr5gewiR0Zi+5X
+n4fYotj+hK3xGJy1k6EXSEEe9xIeUEa3V5Nu1Q/VhKiOdE+riq5AZIqoVzJ1toIg
+EL6rcAyWxzD0acfJJNs6vEDrrO4E81hKCW5CAbSld+UrAQXBXAhZC+OperQ++UGN
+K+aOQCcHBw2wA7rJ0s3dPJp+IGa7f0+d/DcWiIShJmqRQ9FHgsvhhNQDk+yNFM4s
+yPyW+CjVy4nIhO6KVI48EoYQc3hcuKV9mZSx4fkY7Usvro3Um7wgIdMT7QcVcNzR
+H1gi/A5aSU5vwZmd3nFOYn2t0y7Dyj/bz/NGqpUfmRyB+BVaoTD3e0rhivqLpJJt
+EeNM9Su5o22kB5PLKPcGwegbHsWqdlF+G6f+25vUI9EqFlLt0SxVK83bc/ogGhhH
+r5BQDP4bDfYG7DMfjm/ymtBJiMugjIpgVI7QwVmt5m5qPuQ7tBsBjoGk8iGU0ade
+6BoUr/FGXWqtnQYChFiWsub4Al/O7YdUtfm2YpdRsogFSd79VtFn5Vl4MYI2F84H
+YoFcGYJIIogV6tn8HsPuBaXs6cpptSp+ee2qbj+1RXUL1CfkTIgE4AY2XkE3sPVE
+gFiG3MG+gmL+qCxsymr43f2F31pB
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQCz7yUPhneOn6RC
+AvAZDiAOk15neBeZqc0GhP7B7VvJltGC71+lldfemZeEzKgoE2kvQXrU8KynoxCK
+McaqFN3QXRVRLOlePv7wHNdiB/f7AZMij0tyd3aKFP4mUlnIWbABtst6LboNNaKM
+QpcYVEVY8Wn/O879caUTQoLK4iVDYdY0H/bzNn/JfaTig/GPty3Nf88akKSGzsBr
+NrOekNBgXOyscPcyFlkgHyelPACgm2MwQaXTYzedEPf2U0VUV3B+BqYBMjgsLdER
+TD9XJVosLAagILvAlf1EqA06sMmjsnfO9/D1yByndLq5gws8Vm8Yy985dzppGFe+
+SH6rKiEtsOtMJq6T8tkNKQG4LAta7IrA/V0cp28xKV1cNc0O4JeGB69eaY7n4fB4
+IfMVxjXN5ktl1RcLh27qOUSWq7z87ieF/hDEd5YlzZpm7uQ2+/DIkGLebfaMGXbG
+bcOcpJ+A7Dl5ujI2sn2TPNxYxRM0NYp+y8zwmrs53cq8z8d6j5tg8ajm5EFigs3M
+0oEGwVuCDEmI5r05sgaCoPtVuv3eVy9AhAe4OJpJbjhJwLkm936pmhizJ7nZs/t/
+bZ5oWJT3sSG17lmwf/wPqwDCjpQ0CcNF3Ux5A7i/zlWPbm3J/0xb2vvrcL3JN2hu
+A+DbL27bbNTwHwFDQm72MUuN+yEedwIDAQABAoICAAuYKlwwvv16vfve8pe6uEgY
+KOoj6+lj7qkv4raeU97OkBuOzyv9VtaqMQBGq8NBVPLNlluoUofO0x8EjBejlpN5
+nAkKCtOe3ZCdWyee+dS7yj5c23C5z/Kf3ayce9qUJOpHXB84WRfGz/2XwOK5c2qC
+y+C9et4L96YhEAqAvgP0hvf+40vSxDM4nGpYNDWdiR8H0FGW5nMlWXLPKI3cKQE8
+m6eU8+jPVdjjCQv1rNisipyubkAL0aaWVFQUE5CWvdHxHbtQABygqyshLaew6XmV
+MKwaz95eC97jsU6J28RnmJ7GjUlZJreHpwyTLCMsMqZ3ZJ/wVdw1zFmflEH1SgPq
+/JNd0OONKm8x7nORX9dHEn33Imfyg2jI6tzVx1oAmMWMb9hJ0XjkIyzjfHTPi5KW
+pM3pTUUn6ee4P1T4ReBlatiw2TFgAd18/9gSIaSlENEjslJGQ6/Ndt9O7UNHgwth
+ZNtPovjNLqUobHGXlmwg3haeBshn9iPcjdksAjgtjEyowzq7IpiSxQezXNcMezGM
+Y9UL5Qc/yjQ3t+Vu94Jmnu0TT3lHGWa3zSgI6L+UdBiIsLF6P5YQVloYOYWE3q/n
+HTaORoZlsRKfMIUHmhrZ1keJ4VGqLruSpQHobh3Cfb/xzgOEB3nSwhIK3l2FhSiR
+N9jb0r7kMElO+xlm7NChAoIBAQDllnlfyWnTBGog8+T9eJiODuBfdozy2vCZO8nc
+vp11NC7fLh5NXR16Ju6I+dcXDhPdoOG8H/DScjer82kEINrY7Wb4swNd01cLCg+/
+xVNe9iiLl4Q4m/QOI6ZOUbOfJjH9R8J4Bh/FzR1MXtVktgtsd6JB3zv6V246zDjy
+eMnOImwoj6TH/3hI/g2s5i3GoaC7CK+XjpdfZbVAX5+mnpZxBbOqXt7an1IzYHhx
+hQO8uo/9b2IDxMrWWn80mGj9Fw5AdK1Ef3eMtbyG6iOIR92UEo9ZwlZ9Tang58Sa
+7IFHZko/HcCrS92Hl9YcnYmjG0GDeFl4des+IcVz0AHDhe6RAoIBAQDIolXgCYO3
+zo2MtoBTCr+GcluT4DD16ALz7wd8/jXFqmD3UWCAeaS5IsTno1PmuIpvB7dvwz8B
+6SOpE//J/bECDmhE18UHYOAqkXzzuuEGMCP1TuaCWBq7kWV8GVTRcSGQDxLyf/Yu
+IdxiPQMaCxi0Ffv+aq27Nii1IyV8tyDL3skyGZeQJNW2xjNkngkXsB5Tp7H7tA0G
+lSmld1Rtq2XWcRnHQh9ZVP+FxwkjBkdoX0oAASVQwHsy9Q4hZ5ykxPkIGULj3Hw5
+zvG1RAM5B4GQegK0OfYuX5Ullrz6a/6p/FnGLvRkZGlHML/bHTmrr8ywSvF63Gkd
+oU0nqjPFQ1CHAoIBACoFR4PDno3TwgTz/tZxqyJdEK4ISbXtYpn5OnIfpTwdZ/LL
+QxqPz2RbGc+SQs7icbpfxtEi23X5F71uGKt7w/JuSSl9wkD6/HR1y/oiiKbZ0QPz
+oGyoBpxL5BVzmLepSv77kllbbZdLenBO7ym2tBKPNvBthlHEjNVQKaAfgXgsDrXB
+zLwaQw7BCQm7O2eej4eMCG9p1sTMHceBePwLDKf1DjRBlvJWtLnYj1LfsJZrYw1U
+xJDCBQoEmEGtH5IrFR2w/UGLPvtPDAl5czVvSdvfJcOc8S2P+GbEpNRiMys5Sp+Q
+t4HiqdI2dSbZoqZqx6vjbCTDGGJP1g7jZF8/9TECggEAXOXVj2O4an4oSnQiXNEI
+N29x+bl/0gy4eUw/El/+c+Tc+wbiAPrSC6sOsxaL/bOK3bgb9pLX9MGHcn1BHbzq
+ncIgA2hI4Y64nN06lvv7v0rBC4+Z6dZzok/DRr/P5x5T5Qklw8T+LwQcsBwB+KgU
+qyXWxUmN4bZFCQIaFHISrHMeg6UX6XU0w2loWHlYSnCQyjlGjv4iXd7pJqVnIVSQ
+VceOoRV7wHg7zCyJjX8Vxzz/3ZqqNYa6RLD09wCrphtSF67iqvDnUDkC7+Rq/Zf9
+JPFpmRuRYo19WKdAH0+r3fdrdfk9zdI0cPMgkosordc7lpFM2I9/2GlceTY0vGzb
+twKCAQEArUbkiwUZFjdjAbKS2m0uPJyytB8bZ335szcoMUV665hzU9EJPcWeVY0L
+1FSRu/cig+ZCmpUEc/4JhJVKLEEXgC3BgfHGNHi5PIuvssMT/fJJ9InQe8n4Zq0Q
+eZbrfAewrdH3bTpEf6AxIsrMioLsUQSV12iRQ7olsEP9t5HqRKqwhAnqp+q33XT3
+L++8IcaaEQ3S/sBb23pY+VSWQfKGFVQES+P7yKeNHjBNQpJTPOdM9iLtvriUmNdO
+Gy5HOpLgd10DzXBOI7CgqzFm69Bqk+WFZXGVd9T/Ku69B8XfshoRChGbgHbbEG70
+0xT4AQEuygYVBbUrIerZFpDD+Tw7ww==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.4.11-alpine-3.10/openvpn/firewall.sh
+++ b/variants/2.4.11-alpine-3.10/openvpn/firewall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# This iptables script to controlling traffic in the openvpn tunnel.
+# In this example, clients can only perform DNS, HTTP and HTTPS requests to the world.
+
+# Drop everything by default from tunnel to world
+iptables -P FORWARD DROP
+# Allow DNS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p udp -m udp --dport 53 -m conntrack --ctstate NEW -j ACCEPT
+# Allow HTTP and HTTPS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p tcp -m tcp -m conntrack --ctstate NEW -m multiport --dports 80,443 -j ACCEPT

--- a/variants/2.4.11-alpine-3.10/openvpn/server.conf
+++ b/variants/2.4.11-alpine-3.10/openvpn/server.conf
@@ -1,0 +1,280 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/server.conf
+port 1194
+proto udp
+dev tun
+server 10.8.0.0 255.255.255.0
+ifconfig-pool-persist tun-ipp.txt
+;client-config-dir ccd
+keepalive 10 120
+comp-lzo no
+max-clients 5
+user nobody
+group nogroup
+persist-key
+persist-tun
+status tun.status
+status-version 3
+;log-append server.log
+verb 4
+mute 20
+;duplicate-cn
+tls-version-min 1.2
+cipher AES-256-CBC
+auth SHA512
+key-direction 0
+;crl-verify crl.pem
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            97:80:c6:6b:b5:84:81:b3:2b:f6:56:55:da:67:4d:c8
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=server
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:be:f7:ee:15:bc:b6:e1:04:28:3e:38:6a:61:dd:
+                    ee:fa:61:85:9a:a7:be:44:22:52:b4:cf:7a:86:0e:
+                    21:ae:1e:2b:61:66:17:1f:54:dc:e9:75:27:55:24:
+                    39:fc:ee:92:d1:da:de:e2:5f:01:50:b6:ae:52:1a:
+                    79:6b:8d:56:0d:83:f6:d4:19:50:48:bc:cb:d8:69:
+                    c8:79:d4:ba:82:05:db:aa:58:12:4b:34:1b:15:d1:
+                    28:2d:b7:08:4e:a0:64:fb:c6:b4:e2:8b:61:68:4e:
+                    72:72:cc:da:a2:d8:cb:f5:6a:5d:13:b6:98:d3:0c:
+                    a3:05:7a:21:e3:f9:fb:de:89:be:37:ac:ce:4c:2e:
+                    95:98:9e:48:3c:04:97:cd:a3:36:92:15:12:a4:bf:
+                    46:ea:95:37:0c:6f:09:e1:51:f5:4e:13:9f:f5:68:
+                    65:0e:24:38:62:04:f8:f9:0c:06:72:c9:03:ed:5d:
+                    6f:40:3b:62:ea:a2:79:01:79:d0:58:aa:2c:7f:89:
+                    14:bc:3e:86:c0:5e:58:ac:58:c0:97:fe:65:57:46:
+                    bf:01:cc:d4:d7:64:d8:21:15:02:6b:6a:38:24:bb:
+                    2b:45:c7:79:23:7a:7f:0c:6b:25:d3:ce:e1:3f:e8:
+                    68:6c:31:7a:df:88:49:6d:a3:7e:22:24:08:3d:e1:
+                    6c:87:dd:34:77:d2:a5:eb:f7:e6:74:b9:e2:5f:e4:
+                    ad:49:e1:c0:b4:8f:d9:b5:ac:2d:7b:ba:22:64:8e:
+                    b7:c1:11:11:f1:e1:1f:b9:3e:29:b1:61:9b:8a:1c:
+                    2e:d4:e4:e6:10:5a:5d:e1:f9:1e:54:7b:13:79:dd:
+                    d9:ad:8b:23:c4:8d:a5:8b:f5:17:eb:99:96:5d:c6:
+                    8d:b4:af:8b:4c:2f:08:4d:37:c3:bf:6d:68:99:c4:
+                    f7:47:cc:5d:44:e7:6e:f2:64:b3:7d:bb:9b:c7:e1:
+                    27:cf:73:8d:b2:e2:88:19:6c:bb:6e:cd:4a:0a:79:
+                    a8:7b:9d:c3:b0:59:93:51:20:a1:d8:a2:0f:e5:62:
+                    76:17:b3:bb:aa:bc:3a:73:e7:f6:57:91:6a:cb:d3:
+                    7e:91:38:5e:88:57:e3:d8:3e:31:cd:dc:69:9a:74:
+                    bb:6e:62:c2:ab:5b:8c:f5:80:ff:b4:98:a2:87:15:
+                    72:38:77:76:dc:e2:d1:ac:2f:66:67:ae:c4:33:a8:
+                    86:94:af:41:b1:99:0d:5d:68:df:9a:ec:86:0f:0a:
+                    c9:67:fa:a1:7c:29:47:d3:f1:c1:3d:8a:d1:a4:12:
+                    a6:70:16:37:80:4f:d9:79:61:45:1c:07:77:68:60:
+                    4e:10:ec:94:dd:03:95:b1:37:cc:88:3d:60:cc:32:
+                    37:be:a5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                4A:91:C2:3E:A1:E9:04:C9:C0:9A:8B:CE:D4:37:4D:96:0E:74:FE:90
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication
+            X509v3 Key Usage:
+                Digital Signature, Key Encipherment
+            X509v3 Subject Alternative Name:
+                DNS:server
+    Signature Algorithm: sha256WithRSAEncryption
+         72:b4:75:02:f7:7b:e9:07:c6:79:1b:bb:11:e4:73:4a:b4:76:
+         1c:03:b9:58:8c:0a:80:f0:c6:8c:cc:2a:a7:c7:8c:57:a8:6e:
+         52:19:f0:b5:7c:0f:06:ab:2f:04:0e:99:32:b9:2c:b6:42:f0:
+         f5:5b:97:32:ce:bb:0c:ee:9f:b0:0b:bc:0b:c0:43:1d:7d:04:
+         b4:a1:cf:a0:aa:fe:f1:cc:b4:31:b3:bb:78:ed:0e:60:8d:37:
+         ea:48:a7:b4:2d:6d:64:6e:97:15:aa:e4:9b:b4:68:79:c8:3b:
+         ba:91:0b:db:cd:04:a3:aa:e4:69:59:06:ec:50:68:6d:0d:a6:
+         38:32:55:76:09:10:00:da:ac:a8:9e:ad:ad:95:8f:01:88:c9:
+         40:af:9a:5c:2d:17:34:81:6b:26:65:8a:e5:2a:15:79:13:2d:
+         ae:d8:03:16:6b:e9:b6:cd:f3:cb:d5:4d:5f:40:76:7a:99:99:
+         d5:2f:e8:a1:59:88:01:6b:a1:36:c0:53:dc:46:07:fd:ab:ab:
+         2a:5b:d3:d5:4c:84:c2:fb:48:16:80:80:01:f6:37:80:3a:54:
+         81:11:24:86:a6:a2:9a:73:06:5f:ca:24:8c:20:3a:40:6e:95:
+         8e:44:46:ef:60:bc:9d:11:ad:71:af:61:85:a6:e2:b4:49:c7:
+         fa:bb:ef:b5:c9:02:d2:a2:a5:3b:f6:46:03:dc:58:9f:ff:dc:
+         23:6b:b5:02:4c:1a:1a:80:99:6d:1a:fd:24:fc:32:83:f7:de:
+         fd:2b:b2:45:b7:3b:89:3c:49:0c:3d:0b:05:67:a5:95:00:3d:
+         cd:a7:0a:3b:b5:cd:02:10:09:de:ff:6c:6b:8b:aa:9d:e6:e9:
+         07:83:e2:dd:de:6d:bc:9e:fd:19:77:30:5d:67:12:c2:33:40:
+         0f:13:69:98:02:ef:05:b2:ad:ef:fb:73:15:57:70:46:83:32:
+         a9:05:4d:31:06:3d:44:93:88:69:de:9a:67:b4:6b:b7:0d:6b:
+         69:24:8b:62:52:f7:85:66:8f:84:2d:c0:a7:ff:33:37:7c:f3:
+         d1:1f:8c:b6:16:a3:98:db:6e:aa:e5:eb:d8:ed:06:31:19:ba:
+         01:f1:e6:3e:bc:78:ec:6e:b4:af:6c:8a:49:0f:ff:5a:f0:00:
+         88:d8:66:af:d6:49:31:b5:54:ce:be:07:59:46:bb:67:73:4b:
+         b8:ec:be:16:04:ed:fe:75:57:21:d6:d5:7b:cc:d0:7c:bd:91:
+         d3:6e:61:72:04:30:24:45:0a:0d:16:b6:35:94:49:02:14:8d:
+         2d:1d:71:42:13:9a:02:1e:3c:31:05:b4:76:5b:dd:ff:bb:db:
+         f4:31:b7:47:bb:54:f8:27
+-----BEGIN CERTIFICATE-----
+MIIFYjCCA0qgAwIBAgIRAJeAxmu1hIGzK/ZWVdpnTcgwDQYJKoZIhvcNAQELBQAw
+EzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMjUxMDAyMTE0
+NTEyWjARMQ8wDQYDVQQDDAZzZXJ2ZXIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+ggIKAoICAQC+9+4VvLbhBCg+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzp
+dSdVJDn87pLR2t7iXwFQtq5SGnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV
+0SgttwhOoGT7xrTii2FoTnJyzNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWY
+nkg8BJfNozaSFRKkv0bqlTcMbwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2Lq
+onkBedBYqix/iRS8PobAXlisWMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8M
+ayXTzuE/6GhsMXrfiElto34iJAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17
+uiJkjrfBERHx4R+5PimxYZuKHC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZd
+xo20r4tMLwhNN8O/bWiZxPdHzF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7
+ncOwWZNRIKHYog/lYnYXs7uqvDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKr
+W4z1gP+0mKKHFXI4d3bc4tGsL2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT
+8cE9itGkEqZwFjeAT9l5YUUcB3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABo4Gy
+MIGvMAkGA1UdEwQCMAAwHQYDVR0OBBYEFEqRwj6h6QTJwJqLztQ3TZYOdP6QME4G
+A1UdIwRHMEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhD
+aGFuZ2VNZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwEwYDVR0lBAwwCgYIKwYBBQUH
+AwEwCwYDVR0PBAQDAgWgMBEGA1UdEQQKMAiCBnNlcnZlcjANBgkqhkiG9w0BAQsF
+AAOCAgEAcrR1Avd76QfGeRu7EeRzSrR2HAO5WIwKgPDGjMwqp8eMV6huUhnwtXwP
+BqsvBA6ZMrkstkLw9VuXMs67DO6fsAu8C8BDHX0EtKHPoKr+8cy0MbO7eO0OYI03
+6kintC1tZG6XFarkm7Roecg7upEL280Eo6rkaVkG7FBobQ2mODJVdgkQANqsqJ6t
+rZWPAYjJQK+aXC0XNIFrJmWK5SoVeRMtrtgDFmvpts3zy9VNX0B2epmZ1S/ooVmI
+AWuhNsBT3EYH/aurKlvT1UyEwvtIFoCAAfY3gDpUgREkhqaimnMGX8okjCA6QG6V
+jkRG72C8nRGtca9hhabitEnH+rvvtckC0qKlO/ZGA9xYn//cI2u1AkwaGoCZbRr9
+JPwyg/fe/SuyRbc7iTxJDD0LBWellQA9zacKO7XNAhAJ3v9sa4uqnebpB4Pi3d5t
+vJ79GXcwXWcSwjNADxNpmALvBbKt7/tzFVdwRoMyqQVNMQY9RJOIad6aZ7Rrtw1r
+aSSLYlL3hWaPhC3Ap/8zN3zz0R+MthajmNtuquXr2O0GMRm6AfHmPrx47G60r2yK
+SQ//WvAAiNhmr9ZJMbVUzr4HWUa7Z3NLuOy+FgTt/nVXIdbVe8zQfL2R025hcgQw
+JEUKDRa2NZRJAhSNLR1xQhOaAh48MQW0dlvd/7vb9DG3R7tU+Cc=
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQC+9+4VvLbhBCg+
+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzpdSdVJDn87pLR2t7iXwFQtq5S
+GnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV0SgttwhOoGT7xrTii2FoTnJy
+zNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWYnkg8BJfNozaSFRKkv0bqlTcM
+bwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2LqonkBedBYqix/iRS8PobAXlis
+WMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8MayXTzuE/6GhsMXrfiElto34i
+JAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17uiJkjrfBERHx4R+5PimxYZuK
+HC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZdxo20r4tMLwhNN8O/bWiZxPdH
+zF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7ncOwWZNRIKHYog/lYnYXs7uq
+vDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKrW4z1gP+0mKKHFXI4d3bc4tGs
+L2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT8cE9itGkEqZwFjeAT9l5YUUc
+B3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABAoICAAnfT1OYWevwBxSQXg+JJZ2U
+BRAls9RZ4eSvBSqA+ITD0oJKgM+B15nKEKp6IPVOcBChO/x/5NWDXCeqbrR8rgIs
+3EnCtT/NYsxhS5fgw3ONUfnQa8Gvg+bw1R7n42oNKKtLbnZ3tiVqSMhehr78bi7V
+vNIUEnp2oMbbtXzPo5GxlT/TkyalEd698AYKRr6+vUd4B2q06Lmf1SSzaNNZJVFP
++mj5aJ/+h1up3iUh1gOBGM7gkavEZiyzEYZeAcNTqNE/CO9iXBz9w5/FRs+UuzBz
+29P//tDTyciMCX/8EcL0WhxVX5HR91dxApecjlB7d0qAlFWR+hnM5exl6HcqfC3C
++Uhi5IC+gZjD2KCcHDr9e5WqQ6cu8TeMnoyuHInIV9kUL3Bn1ArOU1dmGS78soeE
+GpqGCRc9Imh8jxs1AVyj9wGzpfuRS8OBpfR5MIlcFwSlZO/6dnJSaF2BH1jnKgBG
+Xn9MvjfHTU/EhLTteXrAJlqQr4e/uAK5QCESFNXLvC0r3qord6b9Y0zHR63SpESJ
+WVUIF9L2fIh0Z4CutPegcbEyWLaaAT4njyR4uCI78g77kK+PGi2NM65Mk+wKt975
+m3Qh4/cNv1ews4h+RflayWC9kiiRVzDHJGTy63k5gdplqrW2rb8gK3ZQaT2gQp9u
+gjKIIFGyi+EIDSukHNdRAoIBAQDuGvE9k1lSvoPgSusogMk7PWTiZbn8MwlEFueM
+ZJk9k8dMSkqF1k5BXG9lHcWuFl2invgTiFJIF7ML0GDsFJR+CzCDsanSGdjyKfGM
+HzHAc7UPAJYBXPX1rxTAhGSirKjArcqYUX3ZGGaTo1yZrsbbarInUhWWNKFBdaQ+
++L3oClGt3GZx7hdxapI/3gnkLvG/C5hWWetLONZAxY6jwJJSA/p2Fx93SlWOtrmT
+KRbM/p8m6sHtsXcBnYTueqWYpJ2mnBIB+Svf5acqQ2Xf8kAIw4Vw9u7a15OlIDGF
+ouWhtSkL4s0YfZjlXswOPZDlF3eT2ilf+OIjv5kEcLdDKOojAoIBAQDNUhfys2TH
+b1NFsIH6X1jtWHUEGOYIM/y/75Vw2pGLb40cMxVPtzsNCvz8id/sCuvx6yUWlBlN
+wjpa+7dOA+FgoXwv1iVsQm1zQlrt2VKaEy29C0tRkSwOjNC0bz1409wzYNnh5Bdx
+KJDvSz9zlefAryJGTSgGOothOjnguzoEJ6DxfkxNyWbxceBgN8JljDhc9dcybKdD
+Uxy2GflXhZvZfCtTbYfWoIV+dTYyZt2QE4PEPXrJHGUFE9ncGynbzAn1Cc/zGBeT
+zFNoYOCWNr7ueRNHQYMRZ1N3dYRdZ9th5mdqqa1eY5lP4PyQYZV6lwmyEfitXwNz
+vhS0sO+pNAyXAoIBAB9OiZOoESGRDTPrhdnwfQT+AIrIB1lCuKAsRsut2nw/NwAv
+8HaChA2SAs+Px5MpO6yLLGEdFnyGKTOPdX71AcVE4V8feA24+k50916OJ3N/gzny
+wMZzG5/vIlJh1f2RqCqVb0LxzBNEYxBcdWt7kIf/EmebIl16lA1QU4U4HXgqCy1K
+AmpOfOSbt5kQL8rB5WVSN/h6oDZmxb0EfMnJIzQHc+IdDjUYIAHAwsu3pljTzcdH
+LLJ9GAGtXXIhzC4yzsu+T5vU0FEDGCS1ceqtJoBAfQYqYaOCntYiUoCYt4q4kCoQ
+6xiiQv09pqTksW191WoqUDBfQBSlN5Be5am98nMCggEAIzEb+7R15J0XN82uKZzo
+IB5WSDKAUw2eF8PX6HT+F1kyZY/36ibszyp//EUhhVLF6Dw2qi0OPT66Q9f7LjsK
+CUcEgyqAVZL5MZVBAp2KQ/BfmZRy/3MTixbluteKQMiHaKMEFWzD+9hJJ0rNgGFE
+TMl35XbaEl88fpi9TOCqbAXi1yGfsIGBzIaJP9Su1Dr5ei2FChaHgMmhFTFUhITZ
+FqjqwCz46HexCeDLPk5VUZmWry8eeZQNWJZzc/+P6CWL210oMHGDsQiHj09zjyup
+BDTqcf8vmO8N5l7VJjFj797PAQA+P/xwTbmxcInZVh7HQadE6WpsrAz7fZEKMwVB
+1wKCAQEA3oqXI9bGGoXFjydUiNMZbuHdIDQCa9t7iDb+J+NAiA7GI8W8DlFYrUST
+S/CoBey/WOW9jPT/A8EBnp8RmPtAJH88qklbqh/YCoKyKZrgqT5IGysRLWwDFrGT
+QoOvR1a6SaVMLskmYUCkl8Yz8sZS58X50ahxx5TB0I3xsoCmnMZt+cd2C/VXwhFz
+jCiEZIuQlSgQFW4LOFrxrXmI+MDOBWu4zvkztWOnTe+BNgrxndGVI6sdFGzWeNQx
+dQ9imn0UqGSkgnJEj7Lq67ey8Cuu6yYWexKI0N9UOcyL4FgaEdWiJ0t5KY6NElGI
+0jrZX7pwVf/pvbKW2zVm6nXjWJ/JFw==
+-----END PRIVATE KEY-----
+</key>
+<dh>
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEAqJI9Luwkfy0E95gqZyq031Fa1rUCW5aBoppgm4YHxGUL+fUQzveF
+U2+W5xzmZuxhyoN0PVqlPXoMi0xGyTW4ga8qMaIHDqQ/V8RNxQYJ+GEEiC46/2u9
+Co/HbGX9YXMm5nnNEtHepAHcJiRB6QbCjzVm06x5QfWifj/yTm9ycVfJXhQJiOkD
+j4y4vJbgrmIKWX8Nxj4Q8dCAJzZ2gFvMnW9XcbS9SYbyvS0DvoQG3gPTGcopv7x1
+NiOhrxcTcMjwi/2z6kxG0MJEZ1HOJ2xTtRReUGXkL0lhbVTzkX4V6ihWK4MZYqe+
+ozy/0gbPAB4dT1QNeSRXPOi9f81Oed0SoC83P0oiq3JRQq2g7aS9OiwqlRPnVnvH
+q7Uko6+nv8XLbANgbdLXc8I3K78TSedwofxI/atxKncEic0fHV5ai2IdEWt22qxj
+iWVyaiHlWtMosZvuepSPn3cAmfuj0dVPNiRoG97neN8XIOaVZNGmNnI4yM0JEA1h
+Ef4Lh4YpDdqk4Q/nC/zJev8PM1XC+Os1SsGH50YAn8q19TGzI26/Y4jWfqrHswsj
+6vF/lxDS5RRzLIqlEksm84MU1q0AFSe9FaW1NTtKR/PLO1QiSKr718BwzzrDNN9u
+KZJabQ9n1RgLSuMP9zk9A6GUPQ7cZ0fJchUPeuF8Cd7zAV7k4m0RA4MCAQI=
+-----END DH PARAMETERS-----
+</dh>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.4.11-alpine-3.11/Dockerfile
+++ b/variants/2.4.11-alpine-3.11/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.11
+
+RUN apk add --no-cache openvpn~=2.4.11 iptables
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/2.4.11-alpine-3.11/docker-compose.yml
+++ b/variants/2.4.11-alpine-3.11/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '2.1'
+services:
+  openvpn-server:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
+      - NAT_MASQUERADE=1
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/server.conf:/etc/openvpn/server.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    ports:
+      - 1194:1194/udp
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped

--- a/variants/2.4.11-alpine-3.11/docker-entrypoint.sh
+++ b/variants/2.4.11-alpine-3.11/docker-entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+# Env vars
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
+OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
+NAT=${NAT:-1}
+NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
+CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    echo "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
+
+# If no args are passed, run the entrypoint. If a flag is passed, run openvpn directly. Else, run the passed command
+if [ "$#" -eq 0 ]; then
+    # Provision
+    echo "Provisioning tun device"
+    mkdir -p /dev/net
+    if [ ! -c /dev/net/tun ]; then
+        mknod /dev/net/tun c 10 200
+    fi
+    if [ -f "$CUSTOM_FIREWALL_SCRIPT" ]; then
+        echo "Executing custom firewall script: $CUSTOM_FIREWALL_SCRIPT"
+        . "$CUSTOM_FIREWALL_SCRIPT"
+    else
+        echo "Not executing custom firewall script $CUSTOM_FIREWALL_SCRIPT because it does not exist"
+    fi
+    if [ "$NAT" = 1 ]; then
+        echo "NAT is enabled"
+        echo "Provisioning NAT iptables rules"
+        echo "NAT_INTERFACE: $NAT_INTERFACE"
+        if [ "$NAT_MASQUERADE" = 1 ]; then
+            echo "NAT_MASQUERADE is enabled"
+            iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+            if [ -n "$OPENVPN_ROUTES" ]; then
+                echo "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+                for r in $OPENVPN_ROUTES; do
+                    iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+                done
+            else
+                echo "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+            fi
+        else
+            echo "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
+        fi
+    else
+        echo "NAT is disabled."
+        echo "Not adding NAT iptables rules"
+    fi
+
+    echo "Listing iptables rules:"
+    iptables -L -nv
+    echo "Listing iptables NAT rules:"
+    iptables -L -nv -t nat
+
+    # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
+    set openvpn --cd /etc/openvpn --config "$OPENVPN_CONFIG_FILE"
+    echo "openvpn command line: $@"
+    exec "$@"
+elif [ "$#" -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    echo "openvpn command line: $@"
+    exec openvpn "$@"
+fi
+
+exec "$@"

--- a/variants/2.4.11-alpine-3.11/openvpn/client.conf
+++ b/variants/2.4.11-alpine-3.11/openvpn/client.conf
@@ -1,0 +1,258 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/client.conf
+client
+dev tun
+proto udp
+remote openvpn-server 1194
+remote-random
+# Push all traffic into the tunnel
+;redirect-gateway def1 bypass-dhcp
+resolv-retry infinite
+nobind
+user nobody
+group nobody
+persist-key
+persist-tun
+remote-cert-tls server
+cipher AES-256-CBC
+auth SHA512
+comp-lzo
+verb 4
+key-direction 1
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:4e:3e:ee:0c:a0:be:17:77:36:7e:3e:48:bf:5a:f3
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=client-01
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:b3:ef:25:0f:86:77:8e:9f:a4:42:02:f0:19:0e:
+                    20:0e:93:5e:67:78:17:99:a9:cd:06:84:fe:c1:ed:
+                    5b:c9:96:d1:82:ef:5f:a5:95:d7:de:99:97:84:cc:
+                    a8:28:13:69:2f:41:7a:d4:f0:ac:a7:a3:10:8a:31:
+                    c6:aa:14:dd:d0:5d:15:51:2c:e9:5e:3e:fe:f0:1c:
+                    d7:62:07:f7:fb:01:93:22:8f:4b:72:77:76:8a:14:
+                    fe:26:52:59:c8:59:b0:01:b6:cb:7a:2d:ba:0d:35:
+                    a2:8c:42:97:18:54:45:58:f1:69:ff:3b:ce:fd:71:
+                    a5:13:42:82:ca:e2:25:43:61:d6:34:1f:f6:f3:36:
+                    7f:c9:7d:a4:e2:83:f1:8f:b7:2d:cd:7f:cf:1a:90:
+                    a4:86:ce:c0:6b:36:b3:9e:90:d0:60:5c:ec:ac:70:
+                    f7:32:16:59:20:1f:27:a5:3c:00:a0:9b:63:30:41:
+                    a5:d3:63:37:9d:10:f7:f6:53:45:54:57:70:7e:06:
+                    a6:01:32:38:2c:2d:d1:11:4c:3f:57:25:5a:2c:2c:
+                    06:a0:20:bb:c0:95:fd:44:a8:0d:3a:b0:c9:a3:b2:
+                    77:ce:f7:f0:f5:c8:1c:a7:74:ba:b9:83:0b:3c:56:
+                    6f:18:cb:df:39:77:3a:69:18:57:be:48:7e:ab:2a:
+                    21:2d:b0:eb:4c:26:ae:93:f2:d9:0d:29:01:b8:2c:
+                    0b:5a:ec:8a:c0:fd:5d:1c:a7:6f:31:29:5d:5c:35:
+                    cd:0e:e0:97:86:07:af:5e:69:8e:e7:e1:f0:78:21:
+                    f3:15:c6:35:cd:e6:4b:65:d5:17:0b:87:6e:ea:39:
+                    44:96:ab:bc:fc:ee:27:85:fe:10:c4:77:96:25:cd:
+                    9a:66:ee:e4:36:fb:f0:c8:90:62:de:6d:f6:8c:19:
+                    76:c6:6d:c3:9c:a4:9f:80:ec:39:79:ba:32:36:b2:
+                    7d:93:3c:dc:58:c5:13:34:35:8a:7e:cb:cc:f0:9a:
+                    bb:39:dd:ca:bc:cf:c7:7a:8f:9b:60:f1:a8:e6:e4:
+                    41:62:82:cd:cc:d2:81:06:c1:5b:82:0c:49:88:e6:
+                    bd:39:b2:06:82:a0:fb:55:ba:fd:de:57:2f:40:84:
+                    07:b8:38:9a:49:6e:38:49:c0:b9:26:f7:7e:a9:9a:
+                    18:b3:27:b9:d9:b3:fb:7f:6d:9e:68:58:94:f7:b1:
+                    21:b5:ee:59:b0:7f:fc:0f:ab:00:c2:8e:94:34:09:
+                    c3:45:dd:4c:79:03:b8:bf:ce:55:8f:6e:6d:c9:ff:
+                    4c:5b:da:fb:eb:70:bd:c9:37:68:6e:03:e0:db:2f:
+                    6e:db:6c:d4:f0:1f:01:43:42:6e:f6:31:4b:8d:fb:
+                    21:1e:77
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                23:46:34:1C:74:3B:D8:21:40:4D:81:B3:58:9F:57:CB:0C:5E:90:FB
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+    Signature Algorithm: sha256WithRSAEncryption
+         3c:80:ef:a8:a1:94:bc:12:33:6c:19:2e:44:44:6c:20:8e:69:
+         f6:b8:21:ad:4b:f7:14:d6:bf:c3:8d:b0:87:d1:e2:55:df:c0:
+         fd:03:31:82:8a:82:dd:68:3d:61:1f:c4:89:eb:e6:07:b0:89:
+         1d:19:8b:ee:57:9f:87:d8:a2:d8:fe:84:ad:f1:18:9c:b5:93:
+         a1:17:48:41:1e:f7:12:1e:50:46:b7:57:93:6e:d5:0f:d5:84:
+         a8:8e:74:4f:ab:8a:ae:40:64:8a:a8:57:32:75:b6:82:20:10:
+         be:ab:70:0c:96:c7:30:f4:69:c7:c9:24:db:3a:bc:40:eb:ac:
+         ee:04:f3:58:4a:09:6e:42:01:b4:a5:77:e5:2b:01:05:c1:5c:
+         08:59:0b:e3:a9:7a:b4:3e:f9:41:8d:2b:e6:8e:40:27:07:07:
+         0d:b0:03:ba:c9:d2:cd:dd:3c:9a:7e:20:66:bb:7f:4f:9d:fc:
+         37:16:88:84:a1:26:6a:91:43:d1:47:82:cb:e1:84:d4:03:93:
+         ec:8d:14:ce:2c:c8:fc:96:f8:28:d5:cb:89:c8:84:ee:8a:54:
+         8e:3c:12:86:10:73:78:5c:b8:a5:7d:99:94:b1:e1:f9:18:ed:
+         4b:2f:ae:8d:d4:9b:bc:20:21:d3:13:ed:07:15:70:dc:d1:1f:
+         58:22:fc:0e:5a:49:4e:6f:c1:99:9d:de:71:4e:62:7d:ad:d3:
+         2e:c3:ca:3f:db:cf:f3:46:aa:95:1f:99:1c:81:f8:15:5a:a1:
+         30:f7:7b:4a:e1:8a:fa:8b:a4:92:6d:11:e3:4c:f5:2b:b9:a3:
+         6d:a4:07:93:cb:28:f7:06:c1:e8:1b:1e:c5:aa:76:51:7e:1b:
+         a7:fe:db:9b:d4:23:d1:2a:16:52:ed:d1:2c:55:2b:cd:db:73:
+         fa:20:1a:18:47:af:90:50:0c:fe:1b:0d:f6:06:ec:33:1f:8e:
+         6f:f2:9a:d0:49:88:cb:a0:8c:8a:60:54:8e:d0:c1:59:ad:e6:
+         6e:6a:3e:e4:3b:b4:1b:01:8e:81:a4:f2:21:94:d1:a7:5e:e8:
+         1a:14:af:f1:46:5d:6a:ad:9d:06:02:84:58:96:b2:e6:f8:02:
+         5f:ce:ed:87:54:b5:f9:b6:62:97:51:b2:88:05:49:de:fd:56:
+         d1:67:e5:59:78:31:82:36:17:ce:07:62:81:5c:19:82:48:22:
+         88:15:ea:d9:fc:1e:c3:ee:05:a5:ec:e9:ca:69:b5:2a:7e:79:
+         ed:aa:6e:3f:b5:45:75:0b:d4:27:e4:4c:88:04:e0:06:36:5e:
+         41:37:b0:f5:44:80:58:86:dc:c1:be:82:62:fe:a8:2c:6c:ca:
+         6a:f8:dd:fd:85:df:5a:41
+-----BEGIN CERTIFICATE-----
+MIIFUTCCAzmgAwIBAgIQDU4+7gygvhd3Nn4+SL9a8zANBgkqhkiG9w0BAQsFADAT
+MREwDwYDVQQDDAhDaGFuZ2VNZTAeFw0yMzA2MzAxMTQ1MTJaFw0yNTEwMDIxMTQ1
+MTJaMBQxEjAQBgNVBAMMCWNsaWVudC0wMTCCAiIwDQYJKoZIhvcNAQEBBQADggIP
+ADCCAgoCggIBALPvJQ+Gd46fpEIC8BkOIA6TXmd4F5mpzQaE/sHtW8mW0YLvX6WV
+196Zl4TMqCgTaS9BetTwrKejEIoxxqoU3dBdFVEs6V4+/vAc12IH9/sBkyKPS3J3
+dooU/iZSWchZsAG2y3otug01ooxClxhURVjxaf87zv1xpRNCgsriJUNh1jQf9vM2
+f8l9pOKD8Y+3Lc1/zxqQpIbOwGs2s56Q0GBc7Kxw9zIWWSAfJ6U8AKCbYzBBpdNj
+N50Q9/ZTRVRXcH4GpgEyOCwt0RFMP1clWiwsBqAgu8CV/USoDTqwyaOyd8738PXI
+HKd0urmDCzxWbxjL3zl3OmkYV75IfqsqIS2w60wmrpPy2Q0pAbgsC1rsisD9XRyn
+bzEpXVw1zQ7gl4YHr15pjufh8Hgh8xXGNc3mS2XVFwuHbuo5RJarvPzuJ4X+EMR3
+liXNmmbu5Db78MiQYt5t9owZdsZtw5ykn4DsOXm6MjayfZM83FjFEzQ1in7LzPCa
+uzndyrzPx3qPm2DxqObkQWKCzczSgQbBW4IMSYjmvTmyBoKg+1W6/d5XL0CEB7g4
+mkluOEnAuSb3fqmaGLMnudmz+39tnmhYlPexIbXuWbB//A+rAMKOlDQJw0XdTHkD
+uL/OVY9ubcn/TFva++twvck3aG4D4Nsvbtts1PAfAUNCbvYxS437IR53AgMBAAGj
+gZ8wgZwwCQYDVR0TBAIwADAdBgNVHQ4EFgQUI0Y0HHQ72CFATYGzWJ9XywxekPsw
+TgYDVR0jBEcwRYAUmBuw7bvaYZi1OnrIxE4ycKX4qQehF6QVMBMxETAPBgNVBAMM
+CENoYW5nZU1lghQRFLv/ZzUIweAY3+3bxHLwDm1FLDATBgNVHSUEDDAKBggrBgEF
+BQcDAjALBgNVHQ8EBAMCB4AwDQYJKoZIhvcNAQELBQADggIBADyA76ihlLwSM2wZ
+LkREbCCOafa4Ia1L9xTWv8ONsIfR4lXfwP0DMYKKgt1oPWEfxInr5gewiR0Zi+5X
+n4fYotj+hK3xGJy1k6EXSEEe9xIeUEa3V5Nu1Q/VhKiOdE+riq5AZIqoVzJ1toIg
+EL6rcAyWxzD0acfJJNs6vEDrrO4E81hKCW5CAbSld+UrAQXBXAhZC+OperQ++UGN
+K+aOQCcHBw2wA7rJ0s3dPJp+IGa7f0+d/DcWiIShJmqRQ9FHgsvhhNQDk+yNFM4s
+yPyW+CjVy4nIhO6KVI48EoYQc3hcuKV9mZSx4fkY7Usvro3Um7wgIdMT7QcVcNzR
+H1gi/A5aSU5vwZmd3nFOYn2t0y7Dyj/bz/NGqpUfmRyB+BVaoTD3e0rhivqLpJJt
+EeNM9Su5o22kB5PLKPcGwegbHsWqdlF+G6f+25vUI9EqFlLt0SxVK83bc/ogGhhH
+r5BQDP4bDfYG7DMfjm/ymtBJiMugjIpgVI7QwVmt5m5qPuQ7tBsBjoGk8iGU0ade
+6BoUr/FGXWqtnQYChFiWsub4Al/O7YdUtfm2YpdRsogFSd79VtFn5Vl4MYI2F84H
+YoFcGYJIIogV6tn8HsPuBaXs6cpptSp+ee2qbj+1RXUL1CfkTIgE4AY2XkE3sPVE
+gFiG3MG+gmL+qCxsymr43f2F31pB
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQCz7yUPhneOn6RC
+AvAZDiAOk15neBeZqc0GhP7B7VvJltGC71+lldfemZeEzKgoE2kvQXrU8KynoxCK
+McaqFN3QXRVRLOlePv7wHNdiB/f7AZMij0tyd3aKFP4mUlnIWbABtst6LboNNaKM
+QpcYVEVY8Wn/O879caUTQoLK4iVDYdY0H/bzNn/JfaTig/GPty3Nf88akKSGzsBr
+NrOekNBgXOyscPcyFlkgHyelPACgm2MwQaXTYzedEPf2U0VUV3B+BqYBMjgsLdER
+TD9XJVosLAagILvAlf1EqA06sMmjsnfO9/D1yByndLq5gws8Vm8Yy985dzppGFe+
+SH6rKiEtsOtMJq6T8tkNKQG4LAta7IrA/V0cp28xKV1cNc0O4JeGB69eaY7n4fB4
+IfMVxjXN5ktl1RcLh27qOUSWq7z87ieF/hDEd5YlzZpm7uQ2+/DIkGLebfaMGXbG
+bcOcpJ+A7Dl5ujI2sn2TPNxYxRM0NYp+y8zwmrs53cq8z8d6j5tg8ajm5EFigs3M
+0oEGwVuCDEmI5r05sgaCoPtVuv3eVy9AhAe4OJpJbjhJwLkm936pmhizJ7nZs/t/
+bZ5oWJT3sSG17lmwf/wPqwDCjpQ0CcNF3Ux5A7i/zlWPbm3J/0xb2vvrcL3JN2hu
+A+DbL27bbNTwHwFDQm72MUuN+yEedwIDAQABAoICAAuYKlwwvv16vfve8pe6uEgY
+KOoj6+lj7qkv4raeU97OkBuOzyv9VtaqMQBGq8NBVPLNlluoUofO0x8EjBejlpN5
+nAkKCtOe3ZCdWyee+dS7yj5c23C5z/Kf3ayce9qUJOpHXB84WRfGz/2XwOK5c2qC
+y+C9et4L96YhEAqAvgP0hvf+40vSxDM4nGpYNDWdiR8H0FGW5nMlWXLPKI3cKQE8
+m6eU8+jPVdjjCQv1rNisipyubkAL0aaWVFQUE5CWvdHxHbtQABygqyshLaew6XmV
+MKwaz95eC97jsU6J28RnmJ7GjUlZJreHpwyTLCMsMqZ3ZJ/wVdw1zFmflEH1SgPq
+/JNd0OONKm8x7nORX9dHEn33Imfyg2jI6tzVx1oAmMWMb9hJ0XjkIyzjfHTPi5KW
+pM3pTUUn6ee4P1T4ReBlatiw2TFgAd18/9gSIaSlENEjslJGQ6/Ndt9O7UNHgwth
+ZNtPovjNLqUobHGXlmwg3haeBshn9iPcjdksAjgtjEyowzq7IpiSxQezXNcMezGM
+Y9UL5Qc/yjQ3t+Vu94Jmnu0TT3lHGWa3zSgI6L+UdBiIsLF6P5YQVloYOYWE3q/n
+HTaORoZlsRKfMIUHmhrZ1keJ4VGqLruSpQHobh3Cfb/xzgOEB3nSwhIK3l2FhSiR
+N9jb0r7kMElO+xlm7NChAoIBAQDllnlfyWnTBGog8+T9eJiODuBfdozy2vCZO8nc
+vp11NC7fLh5NXR16Ju6I+dcXDhPdoOG8H/DScjer82kEINrY7Wb4swNd01cLCg+/
+xVNe9iiLl4Q4m/QOI6ZOUbOfJjH9R8J4Bh/FzR1MXtVktgtsd6JB3zv6V246zDjy
+eMnOImwoj6TH/3hI/g2s5i3GoaC7CK+XjpdfZbVAX5+mnpZxBbOqXt7an1IzYHhx
+hQO8uo/9b2IDxMrWWn80mGj9Fw5AdK1Ef3eMtbyG6iOIR92UEo9ZwlZ9Tang58Sa
+7IFHZko/HcCrS92Hl9YcnYmjG0GDeFl4des+IcVz0AHDhe6RAoIBAQDIolXgCYO3
+zo2MtoBTCr+GcluT4DD16ALz7wd8/jXFqmD3UWCAeaS5IsTno1PmuIpvB7dvwz8B
+6SOpE//J/bECDmhE18UHYOAqkXzzuuEGMCP1TuaCWBq7kWV8GVTRcSGQDxLyf/Yu
+IdxiPQMaCxi0Ffv+aq27Nii1IyV8tyDL3skyGZeQJNW2xjNkngkXsB5Tp7H7tA0G
+lSmld1Rtq2XWcRnHQh9ZVP+FxwkjBkdoX0oAASVQwHsy9Q4hZ5ykxPkIGULj3Hw5
+zvG1RAM5B4GQegK0OfYuX5Ullrz6a/6p/FnGLvRkZGlHML/bHTmrr8ywSvF63Gkd
+oU0nqjPFQ1CHAoIBACoFR4PDno3TwgTz/tZxqyJdEK4ISbXtYpn5OnIfpTwdZ/LL
+QxqPz2RbGc+SQs7icbpfxtEi23X5F71uGKt7w/JuSSl9wkD6/HR1y/oiiKbZ0QPz
+oGyoBpxL5BVzmLepSv77kllbbZdLenBO7ym2tBKPNvBthlHEjNVQKaAfgXgsDrXB
+zLwaQw7BCQm7O2eej4eMCG9p1sTMHceBePwLDKf1DjRBlvJWtLnYj1LfsJZrYw1U
+xJDCBQoEmEGtH5IrFR2w/UGLPvtPDAl5czVvSdvfJcOc8S2P+GbEpNRiMys5Sp+Q
+t4HiqdI2dSbZoqZqx6vjbCTDGGJP1g7jZF8/9TECggEAXOXVj2O4an4oSnQiXNEI
+N29x+bl/0gy4eUw/El/+c+Tc+wbiAPrSC6sOsxaL/bOK3bgb9pLX9MGHcn1BHbzq
+ncIgA2hI4Y64nN06lvv7v0rBC4+Z6dZzok/DRr/P5x5T5Qklw8T+LwQcsBwB+KgU
+qyXWxUmN4bZFCQIaFHISrHMeg6UX6XU0w2loWHlYSnCQyjlGjv4iXd7pJqVnIVSQ
+VceOoRV7wHg7zCyJjX8Vxzz/3ZqqNYa6RLD09wCrphtSF67iqvDnUDkC7+Rq/Zf9
+JPFpmRuRYo19WKdAH0+r3fdrdfk9zdI0cPMgkosordc7lpFM2I9/2GlceTY0vGzb
+twKCAQEArUbkiwUZFjdjAbKS2m0uPJyytB8bZ335szcoMUV665hzU9EJPcWeVY0L
+1FSRu/cig+ZCmpUEc/4JhJVKLEEXgC3BgfHGNHi5PIuvssMT/fJJ9InQe8n4Zq0Q
+eZbrfAewrdH3bTpEf6AxIsrMioLsUQSV12iRQ7olsEP9t5HqRKqwhAnqp+q33XT3
+L++8IcaaEQ3S/sBb23pY+VSWQfKGFVQES+P7yKeNHjBNQpJTPOdM9iLtvriUmNdO
+Gy5HOpLgd10DzXBOI7CgqzFm69Bqk+WFZXGVd9T/Ku69B8XfshoRChGbgHbbEG70
+0xT4AQEuygYVBbUrIerZFpDD+Tw7ww==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.4.11-alpine-3.11/openvpn/firewall.sh
+++ b/variants/2.4.11-alpine-3.11/openvpn/firewall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# This iptables script to controlling traffic in the openvpn tunnel.
+# In this example, clients can only perform DNS, HTTP and HTTPS requests to the world.
+
+# Drop everything by default from tunnel to world
+iptables -P FORWARD DROP
+# Allow DNS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p udp -m udp --dport 53 -m conntrack --ctstate NEW -j ACCEPT
+# Allow HTTP and HTTPS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p tcp -m tcp -m conntrack --ctstate NEW -m multiport --dports 80,443 -j ACCEPT

--- a/variants/2.4.11-alpine-3.11/openvpn/server.conf
+++ b/variants/2.4.11-alpine-3.11/openvpn/server.conf
@@ -1,0 +1,280 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/server.conf
+port 1194
+proto udp
+dev tun
+server 10.8.0.0 255.255.255.0
+ifconfig-pool-persist tun-ipp.txt
+;client-config-dir ccd
+keepalive 10 120
+comp-lzo no
+max-clients 5
+user nobody
+group nogroup
+persist-key
+persist-tun
+status tun.status
+status-version 3
+;log-append server.log
+verb 4
+mute 20
+;duplicate-cn
+tls-version-min 1.2
+cipher AES-256-CBC
+auth SHA512
+key-direction 0
+;crl-verify crl.pem
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            97:80:c6:6b:b5:84:81:b3:2b:f6:56:55:da:67:4d:c8
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=server
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:be:f7:ee:15:bc:b6:e1:04:28:3e:38:6a:61:dd:
+                    ee:fa:61:85:9a:a7:be:44:22:52:b4:cf:7a:86:0e:
+                    21:ae:1e:2b:61:66:17:1f:54:dc:e9:75:27:55:24:
+                    39:fc:ee:92:d1:da:de:e2:5f:01:50:b6:ae:52:1a:
+                    79:6b:8d:56:0d:83:f6:d4:19:50:48:bc:cb:d8:69:
+                    c8:79:d4:ba:82:05:db:aa:58:12:4b:34:1b:15:d1:
+                    28:2d:b7:08:4e:a0:64:fb:c6:b4:e2:8b:61:68:4e:
+                    72:72:cc:da:a2:d8:cb:f5:6a:5d:13:b6:98:d3:0c:
+                    a3:05:7a:21:e3:f9:fb:de:89:be:37:ac:ce:4c:2e:
+                    95:98:9e:48:3c:04:97:cd:a3:36:92:15:12:a4:bf:
+                    46:ea:95:37:0c:6f:09:e1:51:f5:4e:13:9f:f5:68:
+                    65:0e:24:38:62:04:f8:f9:0c:06:72:c9:03:ed:5d:
+                    6f:40:3b:62:ea:a2:79:01:79:d0:58:aa:2c:7f:89:
+                    14:bc:3e:86:c0:5e:58:ac:58:c0:97:fe:65:57:46:
+                    bf:01:cc:d4:d7:64:d8:21:15:02:6b:6a:38:24:bb:
+                    2b:45:c7:79:23:7a:7f:0c:6b:25:d3:ce:e1:3f:e8:
+                    68:6c:31:7a:df:88:49:6d:a3:7e:22:24:08:3d:e1:
+                    6c:87:dd:34:77:d2:a5:eb:f7:e6:74:b9:e2:5f:e4:
+                    ad:49:e1:c0:b4:8f:d9:b5:ac:2d:7b:ba:22:64:8e:
+                    b7:c1:11:11:f1:e1:1f:b9:3e:29:b1:61:9b:8a:1c:
+                    2e:d4:e4:e6:10:5a:5d:e1:f9:1e:54:7b:13:79:dd:
+                    d9:ad:8b:23:c4:8d:a5:8b:f5:17:eb:99:96:5d:c6:
+                    8d:b4:af:8b:4c:2f:08:4d:37:c3:bf:6d:68:99:c4:
+                    f7:47:cc:5d:44:e7:6e:f2:64:b3:7d:bb:9b:c7:e1:
+                    27:cf:73:8d:b2:e2:88:19:6c:bb:6e:cd:4a:0a:79:
+                    a8:7b:9d:c3:b0:59:93:51:20:a1:d8:a2:0f:e5:62:
+                    76:17:b3:bb:aa:bc:3a:73:e7:f6:57:91:6a:cb:d3:
+                    7e:91:38:5e:88:57:e3:d8:3e:31:cd:dc:69:9a:74:
+                    bb:6e:62:c2:ab:5b:8c:f5:80:ff:b4:98:a2:87:15:
+                    72:38:77:76:dc:e2:d1:ac:2f:66:67:ae:c4:33:a8:
+                    86:94:af:41:b1:99:0d:5d:68:df:9a:ec:86:0f:0a:
+                    c9:67:fa:a1:7c:29:47:d3:f1:c1:3d:8a:d1:a4:12:
+                    a6:70:16:37:80:4f:d9:79:61:45:1c:07:77:68:60:
+                    4e:10:ec:94:dd:03:95:b1:37:cc:88:3d:60:cc:32:
+                    37:be:a5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                4A:91:C2:3E:A1:E9:04:C9:C0:9A:8B:CE:D4:37:4D:96:0E:74:FE:90
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication
+            X509v3 Key Usage:
+                Digital Signature, Key Encipherment
+            X509v3 Subject Alternative Name:
+                DNS:server
+    Signature Algorithm: sha256WithRSAEncryption
+         72:b4:75:02:f7:7b:e9:07:c6:79:1b:bb:11:e4:73:4a:b4:76:
+         1c:03:b9:58:8c:0a:80:f0:c6:8c:cc:2a:a7:c7:8c:57:a8:6e:
+         52:19:f0:b5:7c:0f:06:ab:2f:04:0e:99:32:b9:2c:b6:42:f0:
+         f5:5b:97:32:ce:bb:0c:ee:9f:b0:0b:bc:0b:c0:43:1d:7d:04:
+         b4:a1:cf:a0:aa:fe:f1:cc:b4:31:b3:bb:78:ed:0e:60:8d:37:
+         ea:48:a7:b4:2d:6d:64:6e:97:15:aa:e4:9b:b4:68:79:c8:3b:
+         ba:91:0b:db:cd:04:a3:aa:e4:69:59:06:ec:50:68:6d:0d:a6:
+         38:32:55:76:09:10:00:da:ac:a8:9e:ad:ad:95:8f:01:88:c9:
+         40:af:9a:5c:2d:17:34:81:6b:26:65:8a:e5:2a:15:79:13:2d:
+         ae:d8:03:16:6b:e9:b6:cd:f3:cb:d5:4d:5f:40:76:7a:99:99:
+         d5:2f:e8:a1:59:88:01:6b:a1:36:c0:53:dc:46:07:fd:ab:ab:
+         2a:5b:d3:d5:4c:84:c2:fb:48:16:80:80:01:f6:37:80:3a:54:
+         81:11:24:86:a6:a2:9a:73:06:5f:ca:24:8c:20:3a:40:6e:95:
+         8e:44:46:ef:60:bc:9d:11:ad:71:af:61:85:a6:e2:b4:49:c7:
+         fa:bb:ef:b5:c9:02:d2:a2:a5:3b:f6:46:03:dc:58:9f:ff:dc:
+         23:6b:b5:02:4c:1a:1a:80:99:6d:1a:fd:24:fc:32:83:f7:de:
+         fd:2b:b2:45:b7:3b:89:3c:49:0c:3d:0b:05:67:a5:95:00:3d:
+         cd:a7:0a:3b:b5:cd:02:10:09:de:ff:6c:6b:8b:aa:9d:e6:e9:
+         07:83:e2:dd:de:6d:bc:9e:fd:19:77:30:5d:67:12:c2:33:40:
+         0f:13:69:98:02:ef:05:b2:ad:ef:fb:73:15:57:70:46:83:32:
+         a9:05:4d:31:06:3d:44:93:88:69:de:9a:67:b4:6b:b7:0d:6b:
+         69:24:8b:62:52:f7:85:66:8f:84:2d:c0:a7:ff:33:37:7c:f3:
+         d1:1f:8c:b6:16:a3:98:db:6e:aa:e5:eb:d8:ed:06:31:19:ba:
+         01:f1:e6:3e:bc:78:ec:6e:b4:af:6c:8a:49:0f:ff:5a:f0:00:
+         88:d8:66:af:d6:49:31:b5:54:ce:be:07:59:46:bb:67:73:4b:
+         b8:ec:be:16:04:ed:fe:75:57:21:d6:d5:7b:cc:d0:7c:bd:91:
+         d3:6e:61:72:04:30:24:45:0a:0d:16:b6:35:94:49:02:14:8d:
+         2d:1d:71:42:13:9a:02:1e:3c:31:05:b4:76:5b:dd:ff:bb:db:
+         f4:31:b7:47:bb:54:f8:27
+-----BEGIN CERTIFICATE-----
+MIIFYjCCA0qgAwIBAgIRAJeAxmu1hIGzK/ZWVdpnTcgwDQYJKoZIhvcNAQELBQAw
+EzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMjUxMDAyMTE0
+NTEyWjARMQ8wDQYDVQQDDAZzZXJ2ZXIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+ggIKAoICAQC+9+4VvLbhBCg+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzp
+dSdVJDn87pLR2t7iXwFQtq5SGnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV
+0SgttwhOoGT7xrTii2FoTnJyzNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWY
+nkg8BJfNozaSFRKkv0bqlTcMbwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2Lq
+onkBedBYqix/iRS8PobAXlisWMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8M
+ayXTzuE/6GhsMXrfiElto34iJAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17
+uiJkjrfBERHx4R+5PimxYZuKHC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZd
+xo20r4tMLwhNN8O/bWiZxPdHzF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7
+ncOwWZNRIKHYog/lYnYXs7uqvDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKr
+W4z1gP+0mKKHFXI4d3bc4tGsL2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT
+8cE9itGkEqZwFjeAT9l5YUUcB3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABo4Gy
+MIGvMAkGA1UdEwQCMAAwHQYDVR0OBBYEFEqRwj6h6QTJwJqLztQ3TZYOdP6QME4G
+A1UdIwRHMEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhD
+aGFuZ2VNZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwEwYDVR0lBAwwCgYIKwYBBQUH
+AwEwCwYDVR0PBAQDAgWgMBEGA1UdEQQKMAiCBnNlcnZlcjANBgkqhkiG9w0BAQsF
+AAOCAgEAcrR1Avd76QfGeRu7EeRzSrR2HAO5WIwKgPDGjMwqp8eMV6huUhnwtXwP
+BqsvBA6ZMrkstkLw9VuXMs67DO6fsAu8C8BDHX0EtKHPoKr+8cy0MbO7eO0OYI03
+6kintC1tZG6XFarkm7Roecg7upEL280Eo6rkaVkG7FBobQ2mODJVdgkQANqsqJ6t
+rZWPAYjJQK+aXC0XNIFrJmWK5SoVeRMtrtgDFmvpts3zy9VNX0B2epmZ1S/ooVmI
+AWuhNsBT3EYH/aurKlvT1UyEwvtIFoCAAfY3gDpUgREkhqaimnMGX8okjCA6QG6V
+jkRG72C8nRGtca9hhabitEnH+rvvtckC0qKlO/ZGA9xYn//cI2u1AkwaGoCZbRr9
+JPwyg/fe/SuyRbc7iTxJDD0LBWellQA9zacKO7XNAhAJ3v9sa4uqnebpB4Pi3d5t
+vJ79GXcwXWcSwjNADxNpmALvBbKt7/tzFVdwRoMyqQVNMQY9RJOIad6aZ7Rrtw1r
+aSSLYlL3hWaPhC3Ap/8zN3zz0R+MthajmNtuquXr2O0GMRm6AfHmPrx47G60r2yK
+SQ//WvAAiNhmr9ZJMbVUzr4HWUa7Z3NLuOy+FgTt/nVXIdbVe8zQfL2R025hcgQw
+JEUKDRa2NZRJAhSNLR1xQhOaAh48MQW0dlvd/7vb9DG3R7tU+Cc=
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQC+9+4VvLbhBCg+
+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzpdSdVJDn87pLR2t7iXwFQtq5S
+GnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV0SgttwhOoGT7xrTii2FoTnJy
+zNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWYnkg8BJfNozaSFRKkv0bqlTcM
+bwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2LqonkBedBYqix/iRS8PobAXlis
+WMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8MayXTzuE/6GhsMXrfiElto34i
+JAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17uiJkjrfBERHx4R+5PimxYZuK
+HC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZdxo20r4tMLwhNN8O/bWiZxPdH
+zF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7ncOwWZNRIKHYog/lYnYXs7uq
+vDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKrW4z1gP+0mKKHFXI4d3bc4tGs
+L2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT8cE9itGkEqZwFjeAT9l5YUUc
+B3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABAoICAAnfT1OYWevwBxSQXg+JJZ2U
+BRAls9RZ4eSvBSqA+ITD0oJKgM+B15nKEKp6IPVOcBChO/x/5NWDXCeqbrR8rgIs
+3EnCtT/NYsxhS5fgw3ONUfnQa8Gvg+bw1R7n42oNKKtLbnZ3tiVqSMhehr78bi7V
+vNIUEnp2oMbbtXzPo5GxlT/TkyalEd698AYKRr6+vUd4B2q06Lmf1SSzaNNZJVFP
++mj5aJ/+h1up3iUh1gOBGM7gkavEZiyzEYZeAcNTqNE/CO9iXBz9w5/FRs+UuzBz
+29P//tDTyciMCX/8EcL0WhxVX5HR91dxApecjlB7d0qAlFWR+hnM5exl6HcqfC3C
++Uhi5IC+gZjD2KCcHDr9e5WqQ6cu8TeMnoyuHInIV9kUL3Bn1ArOU1dmGS78soeE
+GpqGCRc9Imh8jxs1AVyj9wGzpfuRS8OBpfR5MIlcFwSlZO/6dnJSaF2BH1jnKgBG
+Xn9MvjfHTU/EhLTteXrAJlqQr4e/uAK5QCESFNXLvC0r3qord6b9Y0zHR63SpESJ
+WVUIF9L2fIh0Z4CutPegcbEyWLaaAT4njyR4uCI78g77kK+PGi2NM65Mk+wKt975
+m3Qh4/cNv1ews4h+RflayWC9kiiRVzDHJGTy63k5gdplqrW2rb8gK3ZQaT2gQp9u
+gjKIIFGyi+EIDSukHNdRAoIBAQDuGvE9k1lSvoPgSusogMk7PWTiZbn8MwlEFueM
+ZJk9k8dMSkqF1k5BXG9lHcWuFl2invgTiFJIF7ML0GDsFJR+CzCDsanSGdjyKfGM
+HzHAc7UPAJYBXPX1rxTAhGSirKjArcqYUX3ZGGaTo1yZrsbbarInUhWWNKFBdaQ+
++L3oClGt3GZx7hdxapI/3gnkLvG/C5hWWetLONZAxY6jwJJSA/p2Fx93SlWOtrmT
+KRbM/p8m6sHtsXcBnYTueqWYpJ2mnBIB+Svf5acqQ2Xf8kAIw4Vw9u7a15OlIDGF
+ouWhtSkL4s0YfZjlXswOPZDlF3eT2ilf+OIjv5kEcLdDKOojAoIBAQDNUhfys2TH
+b1NFsIH6X1jtWHUEGOYIM/y/75Vw2pGLb40cMxVPtzsNCvz8id/sCuvx6yUWlBlN
+wjpa+7dOA+FgoXwv1iVsQm1zQlrt2VKaEy29C0tRkSwOjNC0bz1409wzYNnh5Bdx
+KJDvSz9zlefAryJGTSgGOothOjnguzoEJ6DxfkxNyWbxceBgN8JljDhc9dcybKdD
+Uxy2GflXhZvZfCtTbYfWoIV+dTYyZt2QE4PEPXrJHGUFE9ncGynbzAn1Cc/zGBeT
+zFNoYOCWNr7ueRNHQYMRZ1N3dYRdZ9th5mdqqa1eY5lP4PyQYZV6lwmyEfitXwNz
+vhS0sO+pNAyXAoIBAB9OiZOoESGRDTPrhdnwfQT+AIrIB1lCuKAsRsut2nw/NwAv
+8HaChA2SAs+Px5MpO6yLLGEdFnyGKTOPdX71AcVE4V8feA24+k50916OJ3N/gzny
+wMZzG5/vIlJh1f2RqCqVb0LxzBNEYxBcdWt7kIf/EmebIl16lA1QU4U4HXgqCy1K
+AmpOfOSbt5kQL8rB5WVSN/h6oDZmxb0EfMnJIzQHc+IdDjUYIAHAwsu3pljTzcdH
+LLJ9GAGtXXIhzC4yzsu+T5vU0FEDGCS1ceqtJoBAfQYqYaOCntYiUoCYt4q4kCoQ
+6xiiQv09pqTksW191WoqUDBfQBSlN5Be5am98nMCggEAIzEb+7R15J0XN82uKZzo
+IB5WSDKAUw2eF8PX6HT+F1kyZY/36ibszyp//EUhhVLF6Dw2qi0OPT66Q9f7LjsK
+CUcEgyqAVZL5MZVBAp2KQ/BfmZRy/3MTixbluteKQMiHaKMEFWzD+9hJJ0rNgGFE
+TMl35XbaEl88fpi9TOCqbAXi1yGfsIGBzIaJP9Su1Dr5ei2FChaHgMmhFTFUhITZ
+FqjqwCz46HexCeDLPk5VUZmWry8eeZQNWJZzc/+P6CWL210oMHGDsQiHj09zjyup
+BDTqcf8vmO8N5l7VJjFj797PAQA+P/xwTbmxcInZVh7HQadE6WpsrAz7fZEKMwVB
+1wKCAQEA3oqXI9bGGoXFjydUiNMZbuHdIDQCa9t7iDb+J+NAiA7GI8W8DlFYrUST
+S/CoBey/WOW9jPT/A8EBnp8RmPtAJH88qklbqh/YCoKyKZrgqT5IGysRLWwDFrGT
+QoOvR1a6SaVMLskmYUCkl8Yz8sZS58X50ahxx5TB0I3xsoCmnMZt+cd2C/VXwhFz
+jCiEZIuQlSgQFW4LOFrxrXmI+MDOBWu4zvkztWOnTe+BNgrxndGVI6sdFGzWeNQx
+dQ9imn0UqGSkgnJEj7Lq67ey8Cuu6yYWexKI0N9UOcyL4FgaEdWiJ0t5KY6NElGI
+0jrZX7pwVf/pvbKW2zVm6nXjWJ/JFw==
+-----END PRIVATE KEY-----
+</key>
+<dh>
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEAqJI9Luwkfy0E95gqZyq031Fa1rUCW5aBoppgm4YHxGUL+fUQzveF
+U2+W5xzmZuxhyoN0PVqlPXoMi0xGyTW4ga8qMaIHDqQ/V8RNxQYJ+GEEiC46/2u9
+Co/HbGX9YXMm5nnNEtHepAHcJiRB6QbCjzVm06x5QfWifj/yTm9ycVfJXhQJiOkD
+j4y4vJbgrmIKWX8Nxj4Q8dCAJzZ2gFvMnW9XcbS9SYbyvS0DvoQG3gPTGcopv7x1
+NiOhrxcTcMjwi/2z6kxG0MJEZ1HOJ2xTtRReUGXkL0lhbVTzkX4V6ihWK4MZYqe+
+ozy/0gbPAB4dT1QNeSRXPOi9f81Oed0SoC83P0oiq3JRQq2g7aS9OiwqlRPnVnvH
+q7Uko6+nv8XLbANgbdLXc8I3K78TSedwofxI/atxKncEic0fHV5ai2IdEWt22qxj
+iWVyaiHlWtMosZvuepSPn3cAmfuj0dVPNiRoG97neN8XIOaVZNGmNnI4yM0JEA1h
+Ef4Lh4YpDdqk4Q/nC/zJev8PM1XC+Os1SsGH50YAn8q19TGzI26/Y4jWfqrHswsj
+6vF/lxDS5RRzLIqlEksm84MU1q0AFSe9FaW1NTtKR/PLO1QiSKr718BwzzrDNN9u
+KZJabQ9n1RgLSuMP9zk9A6GUPQ7cZ0fJchUPeuF8Cd7zAV7k4m0RA4MCAQI=
+-----END DH PARAMETERS-----
+</dh>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.4.12-alpine-3.12/Dockerfile
+++ b/variants/2.4.12-alpine-3.12/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.12
+
+RUN apk add --no-cache openvpn~=2.4.12 iptables
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/2.4.12-alpine-3.12/docker-compose.yml
+++ b/variants/2.4.12-alpine-3.12/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '2.1'
+services:
+  openvpn-server:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
+      - NAT_MASQUERADE=1
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/server.conf:/etc/openvpn/server.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    ports:
+      - 1194:1194/udp
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped

--- a/variants/2.4.12-alpine-3.12/docker-entrypoint.sh
+++ b/variants/2.4.12-alpine-3.12/docker-entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+# Env vars
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
+OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
+NAT=${NAT:-1}
+NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
+CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    echo "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
+
+# If no args are passed, run the entrypoint. If a flag is passed, run openvpn directly. Else, run the passed command
+if [ "$#" -eq 0 ]; then
+    # Provision
+    echo "Provisioning tun device"
+    mkdir -p /dev/net
+    if [ ! -c /dev/net/tun ]; then
+        mknod /dev/net/tun c 10 200
+    fi
+    if [ -f "$CUSTOM_FIREWALL_SCRIPT" ]; then
+        echo "Executing custom firewall script: $CUSTOM_FIREWALL_SCRIPT"
+        . "$CUSTOM_FIREWALL_SCRIPT"
+    else
+        echo "Not executing custom firewall script $CUSTOM_FIREWALL_SCRIPT because it does not exist"
+    fi
+    if [ "$NAT" = 1 ]; then
+        echo "NAT is enabled"
+        echo "Provisioning NAT iptables rules"
+        echo "NAT_INTERFACE: $NAT_INTERFACE"
+        if [ "$NAT_MASQUERADE" = 1 ]; then
+            echo "NAT_MASQUERADE is enabled"
+            iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+            if [ -n "$OPENVPN_ROUTES" ]; then
+                echo "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+                for r in $OPENVPN_ROUTES; do
+                    iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+                done
+            else
+                echo "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+            fi
+        else
+            echo "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
+        fi
+    else
+        echo "NAT is disabled."
+        echo "Not adding NAT iptables rules"
+    fi
+
+    echo "Listing iptables rules:"
+    iptables -L -nv
+    echo "Listing iptables NAT rules:"
+    iptables -L -nv -t nat
+
+    # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
+    set openvpn --cd /etc/openvpn --config "$OPENVPN_CONFIG_FILE"
+    echo "openvpn command line: $@"
+    exec "$@"
+elif [ "$#" -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    echo "openvpn command line: $@"
+    exec openvpn "$@"
+fi
+
+exec "$@"

--- a/variants/2.4.12-alpine-3.12/openvpn/client.conf
+++ b/variants/2.4.12-alpine-3.12/openvpn/client.conf
@@ -1,0 +1,258 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/client.conf
+client
+dev tun
+proto udp
+remote openvpn-server 1194
+remote-random
+# Push all traffic into the tunnel
+;redirect-gateway def1 bypass-dhcp
+resolv-retry infinite
+nobind
+user nobody
+group nobody
+persist-key
+persist-tun
+remote-cert-tls server
+cipher AES-256-CBC
+auth SHA512
+comp-lzo
+verb 4
+key-direction 1
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:4e:3e:ee:0c:a0:be:17:77:36:7e:3e:48:bf:5a:f3
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=client-01
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:b3:ef:25:0f:86:77:8e:9f:a4:42:02:f0:19:0e:
+                    20:0e:93:5e:67:78:17:99:a9:cd:06:84:fe:c1:ed:
+                    5b:c9:96:d1:82:ef:5f:a5:95:d7:de:99:97:84:cc:
+                    a8:28:13:69:2f:41:7a:d4:f0:ac:a7:a3:10:8a:31:
+                    c6:aa:14:dd:d0:5d:15:51:2c:e9:5e:3e:fe:f0:1c:
+                    d7:62:07:f7:fb:01:93:22:8f:4b:72:77:76:8a:14:
+                    fe:26:52:59:c8:59:b0:01:b6:cb:7a:2d:ba:0d:35:
+                    a2:8c:42:97:18:54:45:58:f1:69:ff:3b:ce:fd:71:
+                    a5:13:42:82:ca:e2:25:43:61:d6:34:1f:f6:f3:36:
+                    7f:c9:7d:a4:e2:83:f1:8f:b7:2d:cd:7f:cf:1a:90:
+                    a4:86:ce:c0:6b:36:b3:9e:90:d0:60:5c:ec:ac:70:
+                    f7:32:16:59:20:1f:27:a5:3c:00:a0:9b:63:30:41:
+                    a5:d3:63:37:9d:10:f7:f6:53:45:54:57:70:7e:06:
+                    a6:01:32:38:2c:2d:d1:11:4c:3f:57:25:5a:2c:2c:
+                    06:a0:20:bb:c0:95:fd:44:a8:0d:3a:b0:c9:a3:b2:
+                    77:ce:f7:f0:f5:c8:1c:a7:74:ba:b9:83:0b:3c:56:
+                    6f:18:cb:df:39:77:3a:69:18:57:be:48:7e:ab:2a:
+                    21:2d:b0:eb:4c:26:ae:93:f2:d9:0d:29:01:b8:2c:
+                    0b:5a:ec:8a:c0:fd:5d:1c:a7:6f:31:29:5d:5c:35:
+                    cd:0e:e0:97:86:07:af:5e:69:8e:e7:e1:f0:78:21:
+                    f3:15:c6:35:cd:e6:4b:65:d5:17:0b:87:6e:ea:39:
+                    44:96:ab:bc:fc:ee:27:85:fe:10:c4:77:96:25:cd:
+                    9a:66:ee:e4:36:fb:f0:c8:90:62:de:6d:f6:8c:19:
+                    76:c6:6d:c3:9c:a4:9f:80:ec:39:79:ba:32:36:b2:
+                    7d:93:3c:dc:58:c5:13:34:35:8a:7e:cb:cc:f0:9a:
+                    bb:39:dd:ca:bc:cf:c7:7a:8f:9b:60:f1:a8:e6:e4:
+                    41:62:82:cd:cc:d2:81:06:c1:5b:82:0c:49:88:e6:
+                    bd:39:b2:06:82:a0:fb:55:ba:fd:de:57:2f:40:84:
+                    07:b8:38:9a:49:6e:38:49:c0:b9:26:f7:7e:a9:9a:
+                    18:b3:27:b9:d9:b3:fb:7f:6d:9e:68:58:94:f7:b1:
+                    21:b5:ee:59:b0:7f:fc:0f:ab:00:c2:8e:94:34:09:
+                    c3:45:dd:4c:79:03:b8:bf:ce:55:8f:6e:6d:c9:ff:
+                    4c:5b:da:fb:eb:70:bd:c9:37:68:6e:03:e0:db:2f:
+                    6e:db:6c:d4:f0:1f:01:43:42:6e:f6:31:4b:8d:fb:
+                    21:1e:77
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                23:46:34:1C:74:3B:D8:21:40:4D:81:B3:58:9F:57:CB:0C:5E:90:FB
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+    Signature Algorithm: sha256WithRSAEncryption
+         3c:80:ef:a8:a1:94:bc:12:33:6c:19:2e:44:44:6c:20:8e:69:
+         f6:b8:21:ad:4b:f7:14:d6:bf:c3:8d:b0:87:d1:e2:55:df:c0:
+         fd:03:31:82:8a:82:dd:68:3d:61:1f:c4:89:eb:e6:07:b0:89:
+         1d:19:8b:ee:57:9f:87:d8:a2:d8:fe:84:ad:f1:18:9c:b5:93:
+         a1:17:48:41:1e:f7:12:1e:50:46:b7:57:93:6e:d5:0f:d5:84:
+         a8:8e:74:4f:ab:8a:ae:40:64:8a:a8:57:32:75:b6:82:20:10:
+         be:ab:70:0c:96:c7:30:f4:69:c7:c9:24:db:3a:bc:40:eb:ac:
+         ee:04:f3:58:4a:09:6e:42:01:b4:a5:77:e5:2b:01:05:c1:5c:
+         08:59:0b:e3:a9:7a:b4:3e:f9:41:8d:2b:e6:8e:40:27:07:07:
+         0d:b0:03:ba:c9:d2:cd:dd:3c:9a:7e:20:66:bb:7f:4f:9d:fc:
+         37:16:88:84:a1:26:6a:91:43:d1:47:82:cb:e1:84:d4:03:93:
+         ec:8d:14:ce:2c:c8:fc:96:f8:28:d5:cb:89:c8:84:ee:8a:54:
+         8e:3c:12:86:10:73:78:5c:b8:a5:7d:99:94:b1:e1:f9:18:ed:
+         4b:2f:ae:8d:d4:9b:bc:20:21:d3:13:ed:07:15:70:dc:d1:1f:
+         58:22:fc:0e:5a:49:4e:6f:c1:99:9d:de:71:4e:62:7d:ad:d3:
+         2e:c3:ca:3f:db:cf:f3:46:aa:95:1f:99:1c:81:f8:15:5a:a1:
+         30:f7:7b:4a:e1:8a:fa:8b:a4:92:6d:11:e3:4c:f5:2b:b9:a3:
+         6d:a4:07:93:cb:28:f7:06:c1:e8:1b:1e:c5:aa:76:51:7e:1b:
+         a7:fe:db:9b:d4:23:d1:2a:16:52:ed:d1:2c:55:2b:cd:db:73:
+         fa:20:1a:18:47:af:90:50:0c:fe:1b:0d:f6:06:ec:33:1f:8e:
+         6f:f2:9a:d0:49:88:cb:a0:8c:8a:60:54:8e:d0:c1:59:ad:e6:
+         6e:6a:3e:e4:3b:b4:1b:01:8e:81:a4:f2:21:94:d1:a7:5e:e8:
+         1a:14:af:f1:46:5d:6a:ad:9d:06:02:84:58:96:b2:e6:f8:02:
+         5f:ce:ed:87:54:b5:f9:b6:62:97:51:b2:88:05:49:de:fd:56:
+         d1:67:e5:59:78:31:82:36:17:ce:07:62:81:5c:19:82:48:22:
+         88:15:ea:d9:fc:1e:c3:ee:05:a5:ec:e9:ca:69:b5:2a:7e:79:
+         ed:aa:6e:3f:b5:45:75:0b:d4:27:e4:4c:88:04:e0:06:36:5e:
+         41:37:b0:f5:44:80:58:86:dc:c1:be:82:62:fe:a8:2c:6c:ca:
+         6a:f8:dd:fd:85:df:5a:41
+-----BEGIN CERTIFICATE-----
+MIIFUTCCAzmgAwIBAgIQDU4+7gygvhd3Nn4+SL9a8zANBgkqhkiG9w0BAQsFADAT
+MREwDwYDVQQDDAhDaGFuZ2VNZTAeFw0yMzA2MzAxMTQ1MTJaFw0yNTEwMDIxMTQ1
+MTJaMBQxEjAQBgNVBAMMCWNsaWVudC0wMTCCAiIwDQYJKoZIhvcNAQEBBQADggIP
+ADCCAgoCggIBALPvJQ+Gd46fpEIC8BkOIA6TXmd4F5mpzQaE/sHtW8mW0YLvX6WV
+196Zl4TMqCgTaS9BetTwrKejEIoxxqoU3dBdFVEs6V4+/vAc12IH9/sBkyKPS3J3
+dooU/iZSWchZsAG2y3otug01ooxClxhURVjxaf87zv1xpRNCgsriJUNh1jQf9vM2
+f8l9pOKD8Y+3Lc1/zxqQpIbOwGs2s56Q0GBc7Kxw9zIWWSAfJ6U8AKCbYzBBpdNj
+N50Q9/ZTRVRXcH4GpgEyOCwt0RFMP1clWiwsBqAgu8CV/USoDTqwyaOyd8738PXI
+HKd0urmDCzxWbxjL3zl3OmkYV75IfqsqIS2w60wmrpPy2Q0pAbgsC1rsisD9XRyn
+bzEpXVw1zQ7gl4YHr15pjufh8Hgh8xXGNc3mS2XVFwuHbuo5RJarvPzuJ4X+EMR3
+liXNmmbu5Db78MiQYt5t9owZdsZtw5ykn4DsOXm6MjayfZM83FjFEzQ1in7LzPCa
+uzndyrzPx3qPm2DxqObkQWKCzczSgQbBW4IMSYjmvTmyBoKg+1W6/d5XL0CEB7g4
+mkluOEnAuSb3fqmaGLMnudmz+39tnmhYlPexIbXuWbB//A+rAMKOlDQJw0XdTHkD
+uL/OVY9ubcn/TFva++twvck3aG4D4Nsvbtts1PAfAUNCbvYxS437IR53AgMBAAGj
+gZ8wgZwwCQYDVR0TBAIwADAdBgNVHQ4EFgQUI0Y0HHQ72CFATYGzWJ9XywxekPsw
+TgYDVR0jBEcwRYAUmBuw7bvaYZi1OnrIxE4ycKX4qQehF6QVMBMxETAPBgNVBAMM
+CENoYW5nZU1lghQRFLv/ZzUIweAY3+3bxHLwDm1FLDATBgNVHSUEDDAKBggrBgEF
+BQcDAjALBgNVHQ8EBAMCB4AwDQYJKoZIhvcNAQELBQADggIBADyA76ihlLwSM2wZ
+LkREbCCOafa4Ia1L9xTWv8ONsIfR4lXfwP0DMYKKgt1oPWEfxInr5gewiR0Zi+5X
+n4fYotj+hK3xGJy1k6EXSEEe9xIeUEa3V5Nu1Q/VhKiOdE+riq5AZIqoVzJ1toIg
+EL6rcAyWxzD0acfJJNs6vEDrrO4E81hKCW5CAbSld+UrAQXBXAhZC+OperQ++UGN
+K+aOQCcHBw2wA7rJ0s3dPJp+IGa7f0+d/DcWiIShJmqRQ9FHgsvhhNQDk+yNFM4s
+yPyW+CjVy4nIhO6KVI48EoYQc3hcuKV9mZSx4fkY7Usvro3Um7wgIdMT7QcVcNzR
+H1gi/A5aSU5vwZmd3nFOYn2t0y7Dyj/bz/NGqpUfmRyB+BVaoTD3e0rhivqLpJJt
+EeNM9Su5o22kB5PLKPcGwegbHsWqdlF+G6f+25vUI9EqFlLt0SxVK83bc/ogGhhH
+r5BQDP4bDfYG7DMfjm/ymtBJiMugjIpgVI7QwVmt5m5qPuQ7tBsBjoGk8iGU0ade
+6BoUr/FGXWqtnQYChFiWsub4Al/O7YdUtfm2YpdRsogFSd79VtFn5Vl4MYI2F84H
+YoFcGYJIIogV6tn8HsPuBaXs6cpptSp+ee2qbj+1RXUL1CfkTIgE4AY2XkE3sPVE
+gFiG3MG+gmL+qCxsymr43f2F31pB
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQCz7yUPhneOn6RC
+AvAZDiAOk15neBeZqc0GhP7B7VvJltGC71+lldfemZeEzKgoE2kvQXrU8KynoxCK
+McaqFN3QXRVRLOlePv7wHNdiB/f7AZMij0tyd3aKFP4mUlnIWbABtst6LboNNaKM
+QpcYVEVY8Wn/O879caUTQoLK4iVDYdY0H/bzNn/JfaTig/GPty3Nf88akKSGzsBr
+NrOekNBgXOyscPcyFlkgHyelPACgm2MwQaXTYzedEPf2U0VUV3B+BqYBMjgsLdER
+TD9XJVosLAagILvAlf1EqA06sMmjsnfO9/D1yByndLq5gws8Vm8Yy985dzppGFe+
+SH6rKiEtsOtMJq6T8tkNKQG4LAta7IrA/V0cp28xKV1cNc0O4JeGB69eaY7n4fB4
+IfMVxjXN5ktl1RcLh27qOUSWq7z87ieF/hDEd5YlzZpm7uQ2+/DIkGLebfaMGXbG
+bcOcpJ+A7Dl5ujI2sn2TPNxYxRM0NYp+y8zwmrs53cq8z8d6j5tg8ajm5EFigs3M
+0oEGwVuCDEmI5r05sgaCoPtVuv3eVy9AhAe4OJpJbjhJwLkm936pmhizJ7nZs/t/
+bZ5oWJT3sSG17lmwf/wPqwDCjpQ0CcNF3Ux5A7i/zlWPbm3J/0xb2vvrcL3JN2hu
+A+DbL27bbNTwHwFDQm72MUuN+yEedwIDAQABAoICAAuYKlwwvv16vfve8pe6uEgY
+KOoj6+lj7qkv4raeU97OkBuOzyv9VtaqMQBGq8NBVPLNlluoUofO0x8EjBejlpN5
+nAkKCtOe3ZCdWyee+dS7yj5c23C5z/Kf3ayce9qUJOpHXB84WRfGz/2XwOK5c2qC
+y+C9et4L96YhEAqAvgP0hvf+40vSxDM4nGpYNDWdiR8H0FGW5nMlWXLPKI3cKQE8
+m6eU8+jPVdjjCQv1rNisipyubkAL0aaWVFQUE5CWvdHxHbtQABygqyshLaew6XmV
+MKwaz95eC97jsU6J28RnmJ7GjUlZJreHpwyTLCMsMqZ3ZJ/wVdw1zFmflEH1SgPq
+/JNd0OONKm8x7nORX9dHEn33Imfyg2jI6tzVx1oAmMWMb9hJ0XjkIyzjfHTPi5KW
+pM3pTUUn6ee4P1T4ReBlatiw2TFgAd18/9gSIaSlENEjslJGQ6/Ndt9O7UNHgwth
+ZNtPovjNLqUobHGXlmwg3haeBshn9iPcjdksAjgtjEyowzq7IpiSxQezXNcMezGM
+Y9UL5Qc/yjQ3t+Vu94Jmnu0TT3lHGWa3zSgI6L+UdBiIsLF6P5YQVloYOYWE3q/n
+HTaORoZlsRKfMIUHmhrZ1keJ4VGqLruSpQHobh3Cfb/xzgOEB3nSwhIK3l2FhSiR
+N9jb0r7kMElO+xlm7NChAoIBAQDllnlfyWnTBGog8+T9eJiODuBfdozy2vCZO8nc
+vp11NC7fLh5NXR16Ju6I+dcXDhPdoOG8H/DScjer82kEINrY7Wb4swNd01cLCg+/
+xVNe9iiLl4Q4m/QOI6ZOUbOfJjH9R8J4Bh/FzR1MXtVktgtsd6JB3zv6V246zDjy
+eMnOImwoj6TH/3hI/g2s5i3GoaC7CK+XjpdfZbVAX5+mnpZxBbOqXt7an1IzYHhx
+hQO8uo/9b2IDxMrWWn80mGj9Fw5AdK1Ef3eMtbyG6iOIR92UEo9ZwlZ9Tang58Sa
+7IFHZko/HcCrS92Hl9YcnYmjG0GDeFl4des+IcVz0AHDhe6RAoIBAQDIolXgCYO3
+zo2MtoBTCr+GcluT4DD16ALz7wd8/jXFqmD3UWCAeaS5IsTno1PmuIpvB7dvwz8B
+6SOpE//J/bECDmhE18UHYOAqkXzzuuEGMCP1TuaCWBq7kWV8GVTRcSGQDxLyf/Yu
+IdxiPQMaCxi0Ffv+aq27Nii1IyV8tyDL3skyGZeQJNW2xjNkngkXsB5Tp7H7tA0G
+lSmld1Rtq2XWcRnHQh9ZVP+FxwkjBkdoX0oAASVQwHsy9Q4hZ5ykxPkIGULj3Hw5
+zvG1RAM5B4GQegK0OfYuX5Ullrz6a/6p/FnGLvRkZGlHML/bHTmrr8ywSvF63Gkd
+oU0nqjPFQ1CHAoIBACoFR4PDno3TwgTz/tZxqyJdEK4ISbXtYpn5OnIfpTwdZ/LL
+QxqPz2RbGc+SQs7icbpfxtEi23X5F71uGKt7w/JuSSl9wkD6/HR1y/oiiKbZ0QPz
+oGyoBpxL5BVzmLepSv77kllbbZdLenBO7ym2tBKPNvBthlHEjNVQKaAfgXgsDrXB
+zLwaQw7BCQm7O2eej4eMCG9p1sTMHceBePwLDKf1DjRBlvJWtLnYj1LfsJZrYw1U
+xJDCBQoEmEGtH5IrFR2w/UGLPvtPDAl5czVvSdvfJcOc8S2P+GbEpNRiMys5Sp+Q
+t4HiqdI2dSbZoqZqx6vjbCTDGGJP1g7jZF8/9TECggEAXOXVj2O4an4oSnQiXNEI
+N29x+bl/0gy4eUw/El/+c+Tc+wbiAPrSC6sOsxaL/bOK3bgb9pLX9MGHcn1BHbzq
+ncIgA2hI4Y64nN06lvv7v0rBC4+Z6dZzok/DRr/P5x5T5Qklw8T+LwQcsBwB+KgU
+qyXWxUmN4bZFCQIaFHISrHMeg6UX6XU0w2loWHlYSnCQyjlGjv4iXd7pJqVnIVSQ
+VceOoRV7wHg7zCyJjX8Vxzz/3ZqqNYa6RLD09wCrphtSF67iqvDnUDkC7+Rq/Zf9
+JPFpmRuRYo19WKdAH0+r3fdrdfk9zdI0cPMgkosordc7lpFM2I9/2GlceTY0vGzb
+twKCAQEArUbkiwUZFjdjAbKS2m0uPJyytB8bZ335szcoMUV665hzU9EJPcWeVY0L
+1FSRu/cig+ZCmpUEc/4JhJVKLEEXgC3BgfHGNHi5PIuvssMT/fJJ9InQe8n4Zq0Q
+eZbrfAewrdH3bTpEf6AxIsrMioLsUQSV12iRQ7olsEP9t5HqRKqwhAnqp+q33XT3
+L++8IcaaEQ3S/sBb23pY+VSWQfKGFVQES+P7yKeNHjBNQpJTPOdM9iLtvriUmNdO
+Gy5HOpLgd10DzXBOI7CgqzFm69Bqk+WFZXGVd9T/Ku69B8XfshoRChGbgHbbEG70
+0xT4AQEuygYVBbUrIerZFpDD+Tw7ww==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.4.12-alpine-3.12/openvpn/firewall.sh
+++ b/variants/2.4.12-alpine-3.12/openvpn/firewall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# This iptables script to controlling traffic in the openvpn tunnel.
+# In this example, clients can only perform DNS, HTTP and HTTPS requests to the world.
+
+# Drop everything by default from tunnel to world
+iptables -P FORWARD DROP
+# Allow DNS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p udp -m udp --dport 53 -m conntrack --ctstate NEW -j ACCEPT
+# Allow HTTP and HTTPS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p tcp -m tcp -m conntrack --ctstate NEW -m multiport --dports 80,443 -j ACCEPT

--- a/variants/2.4.12-alpine-3.12/openvpn/server.conf
+++ b/variants/2.4.12-alpine-3.12/openvpn/server.conf
@@ -1,0 +1,280 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/server.conf
+port 1194
+proto udp
+dev tun
+server 10.8.0.0 255.255.255.0
+ifconfig-pool-persist tun-ipp.txt
+;client-config-dir ccd
+keepalive 10 120
+comp-lzo no
+max-clients 5
+user nobody
+group nogroup
+persist-key
+persist-tun
+status tun.status
+status-version 3
+;log-append server.log
+verb 4
+mute 20
+;duplicate-cn
+tls-version-min 1.2
+cipher AES-256-CBC
+auth SHA512
+key-direction 0
+;crl-verify crl.pem
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            97:80:c6:6b:b5:84:81:b3:2b:f6:56:55:da:67:4d:c8
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=server
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:be:f7:ee:15:bc:b6:e1:04:28:3e:38:6a:61:dd:
+                    ee:fa:61:85:9a:a7:be:44:22:52:b4:cf:7a:86:0e:
+                    21:ae:1e:2b:61:66:17:1f:54:dc:e9:75:27:55:24:
+                    39:fc:ee:92:d1:da:de:e2:5f:01:50:b6:ae:52:1a:
+                    79:6b:8d:56:0d:83:f6:d4:19:50:48:bc:cb:d8:69:
+                    c8:79:d4:ba:82:05:db:aa:58:12:4b:34:1b:15:d1:
+                    28:2d:b7:08:4e:a0:64:fb:c6:b4:e2:8b:61:68:4e:
+                    72:72:cc:da:a2:d8:cb:f5:6a:5d:13:b6:98:d3:0c:
+                    a3:05:7a:21:e3:f9:fb:de:89:be:37:ac:ce:4c:2e:
+                    95:98:9e:48:3c:04:97:cd:a3:36:92:15:12:a4:bf:
+                    46:ea:95:37:0c:6f:09:e1:51:f5:4e:13:9f:f5:68:
+                    65:0e:24:38:62:04:f8:f9:0c:06:72:c9:03:ed:5d:
+                    6f:40:3b:62:ea:a2:79:01:79:d0:58:aa:2c:7f:89:
+                    14:bc:3e:86:c0:5e:58:ac:58:c0:97:fe:65:57:46:
+                    bf:01:cc:d4:d7:64:d8:21:15:02:6b:6a:38:24:bb:
+                    2b:45:c7:79:23:7a:7f:0c:6b:25:d3:ce:e1:3f:e8:
+                    68:6c:31:7a:df:88:49:6d:a3:7e:22:24:08:3d:e1:
+                    6c:87:dd:34:77:d2:a5:eb:f7:e6:74:b9:e2:5f:e4:
+                    ad:49:e1:c0:b4:8f:d9:b5:ac:2d:7b:ba:22:64:8e:
+                    b7:c1:11:11:f1:e1:1f:b9:3e:29:b1:61:9b:8a:1c:
+                    2e:d4:e4:e6:10:5a:5d:e1:f9:1e:54:7b:13:79:dd:
+                    d9:ad:8b:23:c4:8d:a5:8b:f5:17:eb:99:96:5d:c6:
+                    8d:b4:af:8b:4c:2f:08:4d:37:c3:bf:6d:68:99:c4:
+                    f7:47:cc:5d:44:e7:6e:f2:64:b3:7d:bb:9b:c7:e1:
+                    27:cf:73:8d:b2:e2:88:19:6c:bb:6e:cd:4a:0a:79:
+                    a8:7b:9d:c3:b0:59:93:51:20:a1:d8:a2:0f:e5:62:
+                    76:17:b3:bb:aa:bc:3a:73:e7:f6:57:91:6a:cb:d3:
+                    7e:91:38:5e:88:57:e3:d8:3e:31:cd:dc:69:9a:74:
+                    bb:6e:62:c2:ab:5b:8c:f5:80:ff:b4:98:a2:87:15:
+                    72:38:77:76:dc:e2:d1:ac:2f:66:67:ae:c4:33:a8:
+                    86:94:af:41:b1:99:0d:5d:68:df:9a:ec:86:0f:0a:
+                    c9:67:fa:a1:7c:29:47:d3:f1:c1:3d:8a:d1:a4:12:
+                    a6:70:16:37:80:4f:d9:79:61:45:1c:07:77:68:60:
+                    4e:10:ec:94:dd:03:95:b1:37:cc:88:3d:60:cc:32:
+                    37:be:a5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                4A:91:C2:3E:A1:E9:04:C9:C0:9A:8B:CE:D4:37:4D:96:0E:74:FE:90
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication
+            X509v3 Key Usage:
+                Digital Signature, Key Encipherment
+            X509v3 Subject Alternative Name:
+                DNS:server
+    Signature Algorithm: sha256WithRSAEncryption
+         72:b4:75:02:f7:7b:e9:07:c6:79:1b:bb:11:e4:73:4a:b4:76:
+         1c:03:b9:58:8c:0a:80:f0:c6:8c:cc:2a:a7:c7:8c:57:a8:6e:
+         52:19:f0:b5:7c:0f:06:ab:2f:04:0e:99:32:b9:2c:b6:42:f0:
+         f5:5b:97:32:ce:bb:0c:ee:9f:b0:0b:bc:0b:c0:43:1d:7d:04:
+         b4:a1:cf:a0:aa:fe:f1:cc:b4:31:b3:bb:78:ed:0e:60:8d:37:
+         ea:48:a7:b4:2d:6d:64:6e:97:15:aa:e4:9b:b4:68:79:c8:3b:
+         ba:91:0b:db:cd:04:a3:aa:e4:69:59:06:ec:50:68:6d:0d:a6:
+         38:32:55:76:09:10:00:da:ac:a8:9e:ad:ad:95:8f:01:88:c9:
+         40:af:9a:5c:2d:17:34:81:6b:26:65:8a:e5:2a:15:79:13:2d:
+         ae:d8:03:16:6b:e9:b6:cd:f3:cb:d5:4d:5f:40:76:7a:99:99:
+         d5:2f:e8:a1:59:88:01:6b:a1:36:c0:53:dc:46:07:fd:ab:ab:
+         2a:5b:d3:d5:4c:84:c2:fb:48:16:80:80:01:f6:37:80:3a:54:
+         81:11:24:86:a6:a2:9a:73:06:5f:ca:24:8c:20:3a:40:6e:95:
+         8e:44:46:ef:60:bc:9d:11:ad:71:af:61:85:a6:e2:b4:49:c7:
+         fa:bb:ef:b5:c9:02:d2:a2:a5:3b:f6:46:03:dc:58:9f:ff:dc:
+         23:6b:b5:02:4c:1a:1a:80:99:6d:1a:fd:24:fc:32:83:f7:de:
+         fd:2b:b2:45:b7:3b:89:3c:49:0c:3d:0b:05:67:a5:95:00:3d:
+         cd:a7:0a:3b:b5:cd:02:10:09:de:ff:6c:6b:8b:aa:9d:e6:e9:
+         07:83:e2:dd:de:6d:bc:9e:fd:19:77:30:5d:67:12:c2:33:40:
+         0f:13:69:98:02:ef:05:b2:ad:ef:fb:73:15:57:70:46:83:32:
+         a9:05:4d:31:06:3d:44:93:88:69:de:9a:67:b4:6b:b7:0d:6b:
+         69:24:8b:62:52:f7:85:66:8f:84:2d:c0:a7:ff:33:37:7c:f3:
+         d1:1f:8c:b6:16:a3:98:db:6e:aa:e5:eb:d8:ed:06:31:19:ba:
+         01:f1:e6:3e:bc:78:ec:6e:b4:af:6c:8a:49:0f:ff:5a:f0:00:
+         88:d8:66:af:d6:49:31:b5:54:ce:be:07:59:46:bb:67:73:4b:
+         b8:ec:be:16:04:ed:fe:75:57:21:d6:d5:7b:cc:d0:7c:bd:91:
+         d3:6e:61:72:04:30:24:45:0a:0d:16:b6:35:94:49:02:14:8d:
+         2d:1d:71:42:13:9a:02:1e:3c:31:05:b4:76:5b:dd:ff:bb:db:
+         f4:31:b7:47:bb:54:f8:27
+-----BEGIN CERTIFICATE-----
+MIIFYjCCA0qgAwIBAgIRAJeAxmu1hIGzK/ZWVdpnTcgwDQYJKoZIhvcNAQELBQAw
+EzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMjUxMDAyMTE0
+NTEyWjARMQ8wDQYDVQQDDAZzZXJ2ZXIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+ggIKAoICAQC+9+4VvLbhBCg+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzp
+dSdVJDn87pLR2t7iXwFQtq5SGnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV
+0SgttwhOoGT7xrTii2FoTnJyzNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWY
+nkg8BJfNozaSFRKkv0bqlTcMbwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2Lq
+onkBedBYqix/iRS8PobAXlisWMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8M
+ayXTzuE/6GhsMXrfiElto34iJAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17
+uiJkjrfBERHx4R+5PimxYZuKHC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZd
+xo20r4tMLwhNN8O/bWiZxPdHzF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7
+ncOwWZNRIKHYog/lYnYXs7uqvDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKr
+W4z1gP+0mKKHFXI4d3bc4tGsL2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT
+8cE9itGkEqZwFjeAT9l5YUUcB3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABo4Gy
+MIGvMAkGA1UdEwQCMAAwHQYDVR0OBBYEFEqRwj6h6QTJwJqLztQ3TZYOdP6QME4G
+A1UdIwRHMEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhD
+aGFuZ2VNZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwEwYDVR0lBAwwCgYIKwYBBQUH
+AwEwCwYDVR0PBAQDAgWgMBEGA1UdEQQKMAiCBnNlcnZlcjANBgkqhkiG9w0BAQsF
+AAOCAgEAcrR1Avd76QfGeRu7EeRzSrR2HAO5WIwKgPDGjMwqp8eMV6huUhnwtXwP
+BqsvBA6ZMrkstkLw9VuXMs67DO6fsAu8C8BDHX0EtKHPoKr+8cy0MbO7eO0OYI03
+6kintC1tZG6XFarkm7Roecg7upEL280Eo6rkaVkG7FBobQ2mODJVdgkQANqsqJ6t
+rZWPAYjJQK+aXC0XNIFrJmWK5SoVeRMtrtgDFmvpts3zy9VNX0B2epmZ1S/ooVmI
+AWuhNsBT3EYH/aurKlvT1UyEwvtIFoCAAfY3gDpUgREkhqaimnMGX8okjCA6QG6V
+jkRG72C8nRGtca9hhabitEnH+rvvtckC0qKlO/ZGA9xYn//cI2u1AkwaGoCZbRr9
+JPwyg/fe/SuyRbc7iTxJDD0LBWellQA9zacKO7XNAhAJ3v9sa4uqnebpB4Pi3d5t
+vJ79GXcwXWcSwjNADxNpmALvBbKt7/tzFVdwRoMyqQVNMQY9RJOIad6aZ7Rrtw1r
+aSSLYlL3hWaPhC3Ap/8zN3zz0R+MthajmNtuquXr2O0GMRm6AfHmPrx47G60r2yK
+SQ//WvAAiNhmr9ZJMbVUzr4HWUa7Z3NLuOy+FgTt/nVXIdbVe8zQfL2R025hcgQw
+JEUKDRa2NZRJAhSNLR1xQhOaAh48MQW0dlvd/7vb9DG3R7tU+Cc=
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQC+9+4VvLbhBCg+
+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzpdSdVJDn87pLR2t7iXwFQtq5S
+GnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV0SgttwhOoGT7xrTii2FoTnJy
+zNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWYnkg8BJfNozaSFRKkv0bqlTcM
+bwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2LqonkBedBYqix/iRS8PobAXlis
+WMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8MayXTzuE/6GhsMXrfiElto34i
+JAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17uiJkjrfBERHx4R+5PimxYZuK
+HC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZdxo20r4tMLwhNN8O/bWiZxPdH
+zF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7ncOwWZNRIKHYog/lYnYXs7uq
+vDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKrW4z1gP+0mKKHFXI4d3bc4tGs
+L2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT8cE9itGkEqZwFjeAT9l5YUUc
+B3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABAoICAAnfT1OYWevwBxSQXg+JJZ2U
+BRAls9RZ4eSvBSqA+ITD0oJKgM+B15nKEKp6IPVOcBChO/x/5NWDXCeqbrR8rgIs
+3EnCtT/NYsxhS5fgw3ONUfnQa8Gvg+bw1R7n42oNKKtLbnZ3tiVqSMhehr78bi7V
+vNIUEnp2oMbbtXzPo5GxlT/TkyalEd698AYKRr6+vUd4B2q06Lmf1SSzaNNZJVFP
++mj5aJ/+h1up3iUh1gOBGM7gkavEZiyzEYZeAcNTqNE/CO9iXBz9w5/FRs+UuzBz
+29P//tDTyciMCX/8EcL0WhxVX5HR91dxApecjlB7d0qAlFWR+hnM5exl6HcqfC3C
++Uhi5IC+gZjD2KCcHDr9e5WqQ6cu8TeMnoyuHInIV9kUL3Bn1ArOU1dmGS78soeE
+GpqGCRc9Imh8jxs1AVyj9wGzpfuRS8OBpfR5MIlcFwSlZO/6dnJSaF2BH1jnKgBG
+Xn9MvjfHTU/EhLTteXrAJlqQr4e/uAK5QCESFNXLvC0r3qord6b9Y0zHR63SpESJ
+WVUIF9L2fIh0Z4CutPegcbEyWLaaAT4njyR4uCI78g77kK+PGi2NM65Mk+wKt975
+m3Qh4/cNv1ews4h+RflayWC9kiiRVzDHJGTy63k5gdplqrW2rb8gK3ZQaT2gQp9u
+gjKIIFGyi+EIDSukHNdRAoIBAQDuGvE9k1lSvoPgSusogMk7PWTiZbn8MwlEFueM
+ZJk9k8dMSkqF1k5BXG9lHcWuFl2invgTiFJIF7ML0GDsFJR+CzCDsanSGdjyKfGM
+HzHAc7UPAJYBXPX1rxTAhGSirKjArcqYUX3ZGGaTo1yZrsbbarInUhWWNKFBdaQ+
++L3oClGt3GZx7hdxapI/3gnkLvG/C5hWWetLONZAxY6jwJJSA/p2Fx93SlWOtrmT
+KRbM/p8m6sHtsXcBnYTueqWYpJ2mnBIB+Svf5acqQ2Xf8kAIw4Vw9u7a15OlIDGF
+ouWhtSkL4s0YfZjlXswOPZDlF3eT2ilf+OIjv5kEcLdDKOojAoIBAQDNUhfys2TH
+b1NFsIH6X1jtWHUEGOYIM/y/75Vw2pGLb40cMxVPtzsNCvz8id/sCuvx6yUWlBlN
+wjpa+7dOA+FgoXwv1iVsQm1zQlrt2VKaEy29C0tRkSwOjNC0bz1409wzYNnh5Bdx
+KJDvSz9zlefAryJGTSgGOothOjnguzoEJ6DxfkxNyWbxceBgN8JljDhc9dcybKdD
+Uxy2GflXhZvZfCtTbYfWoIV+dTYyZt2QE4PEPXrJHGUFE9ncGynbzAn1Cc/zGBeT
+zFNoYOCWNr7ueRNHQYMRZ1N3dYRdZ9th5mdqqa1eY5lP4PyQYZV6lwmyEfitXwNz
+vhS0sO+pNAyXAoIBAB9OiZOoESGRDTPrhdnwfQT+AIrIB1lCuKAsRsut2nw/NwAv
+8HaChA2SAs+Px5MpO6yLLGEdFnyGKTOPdX71AcVE4V8feA24+k50916OJ3N/gzny
+wMZzG5/vIlJh1f2RqCqVb0LxzBNEYxBcdWt7kIf/EmebIl16lA1QU4U4HXgqCy1K
+AmpOfOSbt5kQL8rB5WVSN/h6oDZmxb0EfMnJIzQHc+IdDjUYIAHAwsu3pljTzcdH
+LLJ9GAGtXXIhzC4yzsu+T5vU0FEDGCS1ceqtJoBAfQYqYaOCntYiUoCYt4q4kCoQ
+6xiiQv09pqTksW191WoqUDBfQBSlN5Be5am98nMCggEAIzEb+7R15J0XN82uKZzo
+IB5WSDKAUw2eF8PX6HT+F1kyZY/36ibszyp//EUhhVLF6Dw2qi0OPT66Q9f7LjsK
+CUcEgyqAVZL5MZVBAp2KQ/BfmZRy/3MTixbluteKQMiHaKMEFWzD+9hJJ0rNgGFE
+TMl35XbaEl88fpi9TOCqbAXi1yGfsIGBzIaJP9Su1Dr5ei2FChaHgMmhFTFUhITZ
+FqjqwCz46HexCeDLPk5VUZmWry8eeZQNWJZzc/+P6CWL210oMHGDsQiHj09zjyup
+BDTqcf8vmO8N5l7VJjFj797PAQA+P/xwTbmxcInZVh7HQadE6WpsrAz7fZEKMwVB
+1wKCAQEA3oqXI9bGGoXFjydUiNMZbuHdIDQCa9t7iDb+J+NAiA7GI8W8DlFYrUST
+S/CoBey/WOW9jPT/A8EBnp8RmPtAJH88qklbqh/YCoKyKZrgqT5IGysRLWwDFrGT
+QoOvR1a6SaVMLskmYUCkl8Yz8sZS58X50ahxx5TB0I3xsoCmnMZt+cd2C/VXwhFz
+jCiEZIuQlSgQFW4LOFrxrXmI+MDOBWu4zvkztWOnTe+BNgrxndGVI6sdFGzWeNQx
+dQ9imn0UqGSkgnJEj7Lq67ey8Cuu6yYWexKI0N9UOcyL4FgaEdWiJ0t5KY6NElGI
+0jrZX7pwVf/pvbKW2zVm6nXjWJ/JFw==
+-----END PRIVATE KEY-----
+</key>
+<dh>
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEAqJI9Luwkfy0E95gqZyq031Fa1rUCW5aBoppgm4YHxGUL+fUQzveF
+U2+W5xzmZuxhyoN0PVqlPXoMi0xGyTW4ga8qMaIHDqQ/V8RNxQYJ+GEEiC46/2u9
+Co/HbGX9YXMm5nnNEtHepAHcJiRB6QbCjzVm06x5QfWifj/yTm9ycVfJXhQJiOkD
+j4y4vJbgrmIKWX8Nxj4Q8dCAJzZ2gFvMnW9XcbS9SYbyvS0DvoQG3gPTGcopv7x1
+NiOhrxcTcMjwi/2z6kxG0MJEZ1HOJ2xTtRReUGXkL0lhbVTzkX4V6ihWK4MZYqe+
+ozy/0gbPAB4dT1QNeSRXPOi9f81Oed0SoC83P0oiq3JRQq2g7aS9OiwqlRPnVnvH
+q7Uko6+nv8XLbANgbdLXc8I3K78TSedwofxI/atxKncEic0fHV5ai2IdEWt22qxj
+iWVyaiHlWtMosZvuepSPn3cAmfuj0dVPNiRoG97neN8XIOaVZNGmNnI4yM0JEA1h
+Ef4Lh4YpDdqk4Q/nC/zJev8PM1XC+Os1SsGH50YAn8q19TGzI26/Y4jWfqrHswsj
+6vF/lxDS5RRzLIqlEksm84MU1q0AFSe9FaW1NTtKR/PLO1QiSKr718BwzzrDNN9u
+KZJabQ9n1RgLSuMP9zk9A6GUPQ7cZ0fJchUPeuF8Cd7zAV7k4m0RA4MCAQI=
+-----END DH PARAMETERS-----
+</dh>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.4.4-alpine-3.6/Dockerfile
+++ b/variants/2.4.4-alpine-3.6/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.6
+
+RUN apk add --no-cache openvpn>=2.4.4 iptables
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/2.4.4-alpine-3.6/docker-compose.yml
+++ b/variants/2.4.4-alpine-3.6/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '2.1'
+services:
+  openvpn-server:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
+      - NAT_MASQUERADE=1
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/server.conf:/etc/openvpn/server.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    ports:
+      - 1194:1194/udp
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped

--- a/variants/2.4.4-alpine-3.6/docker-entrypoint.sh
+++ b/variants/2.4.4-alpine-3.6/docker-entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+# Env vars
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
+OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
+NAT=${NAT:-1}
+NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
+CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    echo "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
+
+# If no args are passed, run the entrypoint. If a flag is passed, run openvpn directly. Else, run the passed command
+if [ "$#" -eq 0 ]; then
+    # Provision
+    echo "Provisioning tun device"
+    mkdir -p /dev/net
+    if [ ! -c /dev/net/tun ]; then
+        mknod /dev/net/tun c 10 200
+    fi
+    if [ -f "$CUSTOM_FIREWALL_SCRIPT" ]; then
+        echo "Executing custom firewall script: $CUSTOM_FIREWALL_SCRIPT"
+        . "$CUSTOM_FIREWALL_SCRIPT"
+    else
+        echo "Not executing custom firewall script $CUSTOM_FIREWALL_SCRIPT because it does not exist"
+    fi
+    if [ "$NAT" = 1 ]; then
+        echo "NAT is enabled"
+        echo "Provisioning NAT iptables rules"
+        echo "NAT_INTERFACE: $NAT_INTERFACE"
+        if [ "$NAT_MASQUERADE" = 1 ]; then
+            echo "NAT_MASQUERADE is enabled"
+            iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+            if [ -n "$OPENVPN_ROUTES" ]; then
+                echo "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+                for r in $OPENVPN_ROUTES; do
+                    iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+                done
+            else
+                echo "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+            fi
+        else
+            echo "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
+        fi
+    else
+        echo "NAT is disabled."
+        echo "Not adding NAT iptables rules"
+    fi
+
+    echo "Listing iptables rules:"
+    iptables -L -nv
+    echo "Listing iptables NAT rules:"
+    iptables -L -nv -t nat
+
+    # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
+    set openvpn --cd /etc/openvpn --config "$OPENVPN_CONFIG_FILE"
+    echo "openvpn command line: $@"
+    exec "$@"
+elif [ "$#" -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    echo "openvpn command line: $@"
+    exec openvpn "$@"
+fi
+
+exec "$@"

--- a/variants/2.4.4-alpine-3.6/openvpn/client.conf
+++ b/variants/2.4.4-alpine-3.6/openvpn/client.conf
@@ -1,0 +1,258 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/client.conf
+client
+dev tun
+proto udp
+remote openvpn-server 1194
+remote-random
+# Push all traffic into the tunnel
+;redirect-gateway def1 bypass-dhcp
+resolv-retry infinite
+nobind
+user nobody
+group nobody
+persist-key
+persist-tun
+remote-cert-tls server
+cipher AES-256-CBC
+auth SHA512
+comp-lzo
+verb 4
+key-direction 1
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:4e:3e:ee:0c:a0:be:17:77:36:7e:3e:48:bf:5a:f3
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=client-01
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:b3:ef:25:0f:86:77:8e:9f:a4:42:02:f0:19:0e:
+                    20:0e:93:5e:67:78:17:99:a9:cd:06:84:fe:c1:ed:
+                    5b:c9:96:d1:82:ef:5f:a5:95:d7:de:99:97:84:cc:
+                    a8:28:13:69:2f:41:7a:d4:f0:ac:a7:a3:10:8a:31:
+                    c6:aa:14:dd:d0:5d:15:51:2c:e9:5e:3e:fe:f0:1c:
+                    d7:62:07:f7:fb:01:93:22:8f:4b:72:77:76:8a:14:
+                    fe:26:52:59:c8:59:b0:01:b6:cb:7a:2d:ba:0d:35:
+                    a2:8c:42:97:18:54:45:58:f1:69:ff:3b:ce:fd:71:
+                    a5:13:42:82:ca:e2:25:43:61:d6:34:1f:f6:f3:36:
+                    7f:c9:7d:a4:e2:83:f1:8f:b7:2d:cd:7f:cf:1a:90:
+                    a4:86:ce:c0:6b:36:b3:9e:90:d0:60:5c:ec:ac:70:
+                    f7:32:16:59:20:1f:27:a5:3c:00:a0:9b:63:30:41:
+                    a5:d3:63:37:9d:10:f7:f6:53:45:54:57:70:7e:06:
+                    a6:01:32:38:2c:2d:d1:11:4c:3f:57:25:5a:2c:2c:
+                    06:a0:20:bb:c0:95:fd:44:a8:0d:3a:b0:c9:a3:b2:
+                    77:ce:f7:f0:f5:c8:1c:a7:74:ba:b9:83:0b:3c:56:
+                    6f:18:cb:df:39:77:3a:69:18:57:be:48:7e:ab:2a:
+                    21:2d:b0:eb:4c:26:ae:93:f2:d9:0d:29:01:b8:2c:
+                    0b:5a:ec:8a:c0:fd:5d:1c:a7:6f:31:29:5d:5c:35:
+                    cd:0e:e0:97:86:07:af:5e:69:8e:e7:e1:f0:78:21:
+                    f3:15:c6:35:cd:e6:4b:65:d5:17:0b:87:6e:ea:39:
+                    44:96:ab:bc:fc:ee:27:85:fe:10:c4:77:96:25:cd:
+                    9a:66:ee:e4:36:fb:f0:c8:90:62:de:6d:f6:8c:19:
+                    76:c6:6d:c3:9c:a4:9f:80:ec:39:79:ba:32:36:b2:
+                    7d:93:3c:dc:58:c5:13:34:35:8a:7e:cb:cc:f0:9a:
+                    bb:39:dd:ca:bc:cf:c7:7a:8f:9b:60:f1:a8:e6:e4:
+                    41:62:82:cd:cc:d2:81:06:c1:5b:82:0c:49:88:e6:
+                    bd:39:b2:06:82:a0:fb:55:ba:fd:de:57:2f:40:84:
+                    07:b8:38:9a:49:6e:38:49:c0:b9:26:f7:7e:a9:9a:
+                    18:b3:27:b9:d9:b3:fb:7f:6d:9e:68:58:94:f7:b1:
+                    21:b5:ee:59:b0:7f:fc:0f:ab:00:c2:8e:94:34:09:
+                    c3:45:dd:4c:79:03:b8:bf:ce:55:8f:6e:6d:c9:ff:
+                    4c:5b:da:fb:eb:70:bd:c9:37:68:6e:03:e0:db:2f:
+                    6e:db:6c:d4:f0:1f:01:43:42:6e:f6:31:4b:8d:fb:
+                    21:1e:77
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                23:46:34:1C:74:3B:D8:21:40:4D:81:B3:58:9F:57:CB:0C:5E:90:FB
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+    Signature Algorithm: sha256WithRSAEncryption
+         3c:80:ef:a8:a1:94:bc:12:33:6c:19:2e:44:44:6c:20:8e:69:
+         f6:b8:21:ad:4b:f7:14:d6:bf:c3:8d:b0:87:d1:e2:55:df:c0:
+         fd:03:31:82:8a:82:dd:68:3d:61:1f:c4:89:eb:e6:07:b0:89:
+         1d:19:8b:ee:57:9f:87:d8:a2:d8:fe:84:ad:f1:18:9c:b5:93:
+         a1:17:48:41:1e:f7:12:1e:50:46:b7:57:93:6e:d5:0f:d5:84:
+         a8:8e:74:4f:ab:8a:ae:40:64:8a:a8:57:32:75:b6:82:20:10:
+         be:ab:70:0c:96:c7:30:f4:69:c7:c9:24:db:3a:bc:40:eb:ac:
+         ee:04:f3:58:4a:09:6e:42:01:b4:a5:77:e5:2b:01:05:c1:5c:
+         08:59:0b:e3:a9:7a:b4:3e:f9:41:8d:2b:e6:8e:40:27:07:07:
+         0d:b0:03:ba:c9:d2:cd:dd:3c:9a:7e:20:66:bb:7f:4f:9d:fc:
+         37:16:88:84:a1:26:6a:91:43:d1:47:82:cb:e1:84:d4:03:93:
+         ec:8d:14:ce:2c:c8:fc:96:f8:28:d5:cb:89:c8:84:ee:8a:54:
+         8e:3c:12:86:10:73:78:5c:b8:a5:7d:99:94:b1:e1:f9:18:ed:
+         4b:2f:ae:8d:d4:9b:bc:20:21:d3:13:ed:07:15:70:dc:d1:1f:
+         58:22:fc:0e:5a:49:4e:6f:c1:99:9d:de:71:4e:62:7d:ad:d3:
+         2e:c3:ca:3f:db:cf:f3:46:aa:95:1f:99:1c:81:f8:15:5a:a1:
+         30:f7:7b:4a:e1:8a:fa:8b:a4:92:6d:11:e3:4c:f5:2b:b9:a3:
+         6d:a4:07:93:cb:28:f7:06:c1:e8:1b:1e:c5:aa:76:51:7e:1b:
+         a7:fe:db:9b:d4:23:d1:2a:16:52:ed:d1:2c:55:2b:cd:db:73:
+         fa:20:1a:18:47:af:90:50:0c:fe:1b:0d:f6:06:ec:33:1f:8e:
+         6f:f2:9a:d0:49:88:cb:a0:8c:8a:60:54:8e:d0:c1:59:ad:e6:
+         6e:6a:3e:e4:3b:b4:1b:01:8e:81:a4:f2:21:94:d1:a7:5e:e8:
+         1a:14:af:f1:46:5d:6a:ad:9d:06:02:84:58:96:b2:e6:f8:02:
+         5f:ce:ed:87:54:b5:f9:b6:62:97:51:b2:88:05:49:de:fd:56:
+         d1:67:e5:59:78:31:82:36:17:ce:07:62:81:5c:19:82:48:22:
+         88:15:ea:d9:fc:1e:c3:ee:05:a5:ec:e9:ca:69:b5:2a:7e:79:
+         ed:aa:6e:3f:b5:45:75:0b:d4:27:e4:4c:88:04:e0:06:36:5e:
+         41:37:b0:f5:44:80:58:86:dc:c1:be:82:62:fe:a8:2c:6c:ca:
+         6a:f8:dd:fd:85:df:5a:41
+-----BEGIN CERTIFICATE-----
+MIIFUTCCAzmgAwIBAgIQDU4+7gygvhd3Nn4+SL9a8zANBgkqhkiG9w0BAQsFADAT
+MREwDwYDVQQDDAhDaGFuZ2VNZTAeFw0yMzA2MzAxMTQ1MTJaFw0yNTEwMDIxMTQ1
+MTJaMBQxEjAQBgNVBAMMCWNsaWVudC0wMTCCAiIwDQYJKoZIhvcNAQEBBQADggIP
+ADCCAgoCggIBALPvJQ+Gd46fpEIC8BkOIA6TXmd4F5mpzQaE/sHtW8mW0YLvX6WV
+196Zl4TMqCgTaS9BetTwrKejEIoxxqoU3dBdFVEs6V4+/vAc12IH9/sBkyKPS3J3
+dooU/iZSWchZsAG2y3otug01ooxClxhURVjxaf87zv1xpRNCgsriJUNh1jQf9vM2
+f8l9pOKD8Y+3Lc1/zxqQpIbOwGs2s56Q0GBc7Kxw9zIWWSAfJ6U8AKCbYzBBpdNj
+N50Q9/ZTRVRXcH4GpgEyOCwt0RFMP1clWiwsBqAgu8CV/USoDTqwyaOyd8738PXI
+HKd0urmDCzxWbxjL3zl3OmkYV75IfqsqIS2w60wmrpPy2Q0pAbgsC1rsisD9XRyn
+bzEpXVw1zQ7gl4YHr15pjufh8Hgh8xXGNc3mS2XVFwuHbuo5RJarvPzuJ4X+EMR3
+liXNmmbu5Db78MiQYt5t9owZdsZtw5ykn4DsOXm6MjayfZM83FjFEzQ1in7LzPCa
+uzndyrzPx3qPm2DxqObkQWKCzczSgQbBW4IMSYjmvTmyBoKg+1W6/d5XL0CEB7g4
+mkluOEnAuSb3fqmaGLMnudmz+39tnmhYlPexIbXuWbB//A+rAMKOlDQJw0XdTHkD
+uL/OVY9ubcn/TFva++twvck3aG4D4Nsvbtts1PAfAUNCbvYxS437IR53AgMBAAGj
+gZ8wgZwwCQYDVR0TBAIwADAdBgNVHQ4EFgQUI0Y0HHQ72CFATYGzWJ9XywxekPsw
+TgYDVR0jBEcwRYAUmBuw7bvaYZi1OnrIxE4ycKX4qQehF6QVMBMxETAPBgNVBAMM
+CENoYW5nZU1lghQRFLv/ZzUIweAY3+3bxHLwDm1FLDATBgNVHSUEDDAKBggrBgEF
+BQcDAjALBgNVHQ8EBAMCB4AwDQYJKoZIhvcNAQELBQADggIBADyA76ihlLwSM2wZ
+LkREbCCOafa4Ia1L9xTWv8ONsIfR4lXfwP0DMYKKgt1oPWEfxInr5gewiR0Zi+5X
+n4fYotj+hK3xGJy1k6EXSEEe9xIeUEa3V5Nu1Q/VhKiOdE+riq5AZIqoVzJ1toIg
+EL6rcAyWxzD0acfJJNs6vEDrrO4E81hKCW5CAbSld+UrAQXBXAhZC+OperQ++UGN
+K+aOQCcHBw2wA7rJ0s3dPJp+IGa7f0+d/DcWiIShJmqRQ9FHgsvhhNQDk+yNFM4s
+yPyW+CjVy4nIhO6KVI48EoYQc3hcuKV9mZSx4fkY7Usvro3Um7wgIdMT7QcVcNzR
+H1gi/A5aSU5vwZmd3nFOYn2t0y7Dyj/bz/NGqpUfmRyB+BVaoTD3e0rhivqLpJJt
+EeNM9Su5o22kB5PLKPcGwegbHsWqdlF+G6f+25vUI9EqFlLt0SxVK83bc/ogGhhH
+r5BQDP4bDfYG7DMfjm/ymtBJiMugjIpgVI7QwVmt5m5qPuQ7tBsBjoGk8iGU0ade
+6BoUr/FGXWqtnQYChFiWsub4Al/O7YdUtfm2YpdRsogFSd79VtFn5Vl4MYI2F84H
+YoFcGYJIIogV6tn8HsPuBaXs6cpptSp+ee2qbj+1RXUL1CfkTIgE4AY2XkE3sPVE
+gFiG3MG+gmL+qCxsymr43f2F31pB
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQCz7yUPhneOn6RC
+AvAZDiAOk15neBeZqc0GhP7B7VvJltGC71+lldfemZeEzKgoE2kvQXrU8KynoxCK
+McaqFN3QXRVRLOlePv7wHNdiB/f7AZMij0tyd3aKFP4mUlnIWbABtst6LboNNaKM
+QpcYVEVY8Wn/O879caUTQoLK4iVDYdY0H/bzNn/JfaTig/GPty3Nf88akKSGzsBr
+NrOekNBgXOyscPcyFlkgHyelPACgm2MwQaXTYzedEPf2U0VUV3B+BqYBMjgsLdER
+TD9XJVosLAagILvAlf1EqA06sMmjsnfO9/D1yByndLq5gws8Vm8Yy985dzppGFe+
+SH6rKiEtsOtMJq6T8tkNKQG4LAta7IrA/V0cp28xKV1cNc0O4JeGB69eaY7n4fB4
+IfMVxjXN5ktl1RcLh27qOUSWq7z87ieF/hDEd5YlzZpm7uQ2+/DIkGLebfaMGXbG
+bcOcpJ+A7Dl5ujI2sn2TPNxYxRM0NYp+y8zwmrs53cq8z8d6j5tg8ajm5EFigs3M
+0oEGwVuCDEmI5r05sgaCoPtVuv3eVy9AhAe4OJpJbjhJwLkm936pmhizJ7nZs/t/
+bZ5oWJT3sSG17lmwf/wPqwDCjpQ0CcNF3Ux5A7i/zlWPbm3J/0xb2vvrcL3JN2hu
+A+DbL27bbNTwHwFDQm72MUuN+yEedwIDAQABAoICAAuYKlwwvv16vfve8pe6uEgY
+KOoj6+lj7qkv4raeU97OkBuOzyv9VtaqMQBGq8NBVPLNlluoUofO0x8EjBejlpN5
+nAkKCtOe3ZCdWyee+dS7yj5c23C5z/Kf3ayce9qUJOpHXB84WRfGz/2XwOK5c2qC
+y+C9et4L96YhEAqAvgP0hvf+40vSxDM4nGpYNDWdiR8H0FGW5nMlWXLPKI3cKQE8
+m6eU8+jPVdjjCQv1rNisipyubkAL0aaWVFQUE5CWvdHxHbtQABygqyshLaew6XmV
+MKwaz95eC97jsU6J28RnmJ7GjUlZJreHpwyTLCMsMqZ3ZJ/wVdw1zFmflEH1SgPq
+/JNd0OONKm8x7nORX9dHEn33Imfyg2jI6tzVx1oAmMWMb9hJ0XjkIyzjfHTPi5KW
+pM3pTUUn6ee4P1T4ReBlatiw2TFgAd18/9gSIaSlENEjslJGQ6/Ndt9O7UNHgwth
+ZNtPovjNLqUobHGXlmwg3haeBshn9iPcjdksAjgtjEyowzq7IpiSxQezXNcMezGM
+Y9UL5Qc/yjQ3t+Vu94Jmnu0TT3lHGWa3zSgI6L+UdBiIsLF6P5YQVloYOYWE3q/n
+HTaORoZlsRKfMIUHmhrZ1keJ4VGqLruSpQHobh3Cfb/xzgOEB3nSwhIK3l2FhSiR
+N9jb0r7kMElO+xlm7NChAoIBAQDllnlfyWnTBGog8+T9eJiODuBfdozy2vCZO8nc
+vp11NC7fLh5NXR16Ju6I+dcXDhPdoOG8H/DScjer82kEINrY7Wb4swNd01cLCg+/
+xVNe9iiLl4Q4m/QOI6ZOUbOfJjH9R8J4Bh/FzR1MXtVktgtsd6JB3zv6V246zDjy
+eMnOImwoj6TH/3hI/g2s5i3GoaC7CK+XjpdfZbVAX5+mnpZxBbOqXt7an1IzYHhx
+hQO8uo/9b2IDxMrWWn80mGj9Fw5AdK1Ef3eMtbyG6iOIR92UEo9ZwlZ9Tang58Sa
+7IFHZko/HcCrS92Hl9YcnYmjG0GDeFl4des+IcVz0AHDhe6RAoIBAQDIolXgCYO3
+zo2MtoBTCr+GcluT4DD16ALz7wd8/jXFqmD3UWCAeaS5IsTno1PmuIpvB7dvwz8B
+6SOpE//J/bECDmhE18UHYOAqkXzzuuEGMCP1TuaCWBq7kWV8GVTRcSGQDxLyf/Yu
+IdxiPQMaCxi0Ffv+aq27Nii1IyV8tyDL3skyGZeQJNW2xjNkngkXsB5Tp7H7tA0G
+lSmld1Rtq2XWcRnHQh9ZVP+FxwkjBkdoX0oAASVQwHsy9Q4hZ5ykxPkIGULj3Hw5
+zvG1RAM5B4GQegK0OfYuX5Ullrz6a/6p/FnGLvRkZGlHML/bHTmrr8ywSvF63Gkd
+oU0nqjPFQ1CHAoIBACoFR4PDno3TwgTz/tZxqyJdEK4ISbXtYpn5OnIfpTwdZ/LL
+QxqPz2RbGc+SQs7icbpfxtEi23X5F71uGKt7w/JuSSl9wkD6/HR1y/oiiKbZ0QPz
+oGyoBpxL5BVzmLepSv77kllbbZdLenBO7ym2tBKPNvBthlHEjNVQKaAfgXgsDrXB
+zLwaQw7BCQm7O2eej4eMCG9p1sTMHceBePwLDKf1DjRBlvJWtLnYj1LfsJZrYw1U
+xJDCBQoEmEGtH5IrFR2w/UGLPvtPDAl5czVvSdvfJcOc8S2P+GbEpNRiMys5Sp+Q
+t4HiqdI2dSbZoqZqx6vjbCTDGGJP1g7jZF8/9TECggEAXOXVj2O4an4oSnQiXNEI
+N29x+bl/0gy4eUw/El/+c+Tc+wbiAPrSC6sOsxaL/bOK3bgb9pLX9MGHcn1BHbzq
+ncIgA2hI4Y64nN06lvv7v0rBC4+Z6dZzok/DRr/P5x5T5Qklw8T+LwQcsBwB+KgU
+qyXWxUmN4bZFCQIaFHISrHMeg6UX6XU0w2loWHlYSnCQyjlGjv4iXd7pJqVnIVSQ
+VceOoRV7wHg7zCyJjX8Vxzz/3ZqqNYa6RLD09wCrphtSF67iqvDnUDkC7+Rq/Zf9
+JPFpmRuRYo19WKdAH0+r3fdrdfk9zdI0cPMgkosordc7lpFM2I9/2GlceTY0vGzb
+twKCAQEArUbkiwUZFjdjAbKS2m0uPJyytB8bZ335szcoMUV665hzU9EJPcWeVY0L
+1FSRu/cig+ZCmpUEc/4JhJVKLEEXgC3BgfHGNHi5PIuvssMT/fJJ9InQe8n4Zq0Q
+eZbrfAewrdH3bTpEf6AxIsrMioLsUQSV12iRQ7olsEP9t5HqRKqwhAnqp+q33XT3
+L++8IcaaEQ3S/sBb23pY+VSWQfKGFVQES+P7yKeNHjBNQpJTPOdM9iLtvriUmNdO
+Gy5HOpLgd10DzXBOI7CgqzFm69Bqk+WFZXGVd9T/Ku69B8XfshoRChGbgHbbEG70
+0xT4AQEuygYVBbUrIerZFpDD+Tw7ww==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.4.4-alpine-3.6/openvpn/firewall.sh
+++ b/variants/2.4.4-alpine-3.6/openvpn/firewall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# This iptables script to controlling traffic in the openvpn tunnel.
+# In this example, clients can only perform DNS, HTTP and HTTPS requests to the world.
+
+# Drop everything by default from tunnel to world
+iptables -P FORWARD DROP
+# Allow DNS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p udp -m udp --dport 53 -m conntrack --ctstate NEW -j ACCEPT
+# Allow HTTP and HTTPS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p tcp -m tcp -m conntrack --ctstate NEW -m multiport --dports 80,443 -j ACCEPT

--- a/variants/2.4.4-alpine-3.6/openvpn/server.conf
+++ b/variants/2.4.4-alpine-3.6/openvpn/server.conf
@@ -1,0 +1,280 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/server.conf
+port 1194
+proto udp
+dev tun
+server 10.8.0.0 255.255.255.0
+ifconfig-pool-persist tun-ipp.txt
+;client-config-dir ccd
+keepalive 10 120
+comp-lzo no
+max-clients 5
+user nobody
+group nogroup
+persist-key
+persist-tun
+status tun.status
+status-version 3
+;log-append server.log
+verb 4
+mute 20
+;duplicate-cn
+tls-version-min 1.2
+cipher AES-256-CBC
+auth SHA512
+key-direction 0
+;crl-verify crl.pem
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            97:80:c6:6b:b5:84:81:b3:2b:f6:56:55:da:67:4d:c8
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=server
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:be:f7:ee:15:bc:b6:e1:04:28:3e:38:6a:61:dd:
+                    ee:fa:61:85:9a:a7:be:44:22:52:b4:cf:7a:86:0e:
+                    21:ae:1e:2b:61:66:17:1f:54:dc:e9:75:27:55:24:
+                    39:fc:ee:92:d1:da:de:e2:5f:01:50:b6:ae:52:1a:
+                    79:6b:8d:56:0d:83:f6:d4:19:50:48:bc:cb:d8:69:
+                    c8:79:d4:ba:82:05:db:aa:58:12:4b:34:1b:15:d1:
+                    28:2d:b7:08:4e:a0:64:fb:c6:b4:e2:8b:61:68:4e:
+                    72:72:cc:da:a2:d8:cb:f5:6a:5d:13:b6:98:d3:0c:
+                    a3:05:7a:21:e3:f9:fb:de:89:be:37:ac:ce:4c:2e:
+                    95:98:9e:48:3c:04:97:cd:a3:36:92:15:12:a4:bf:
+                    46:ea:95:37:0c:6f:09:e1:51:f5:4e:13:9f:f5:68:
+                    65:0e:24:38:62:04:f8:f9:0c:06:72:c9:03:ed:5d:
+                    6f:40:3b:62:ea:a2:79:01:79:d0:58:aa:2c:7f:89:
+                    14:bc:3e:86:c0:5e:58:ac:58:c0:97:fe:65:57:46:
+                    bf:01:cc:d4:d7:64:d8:21:15:02:6b:6a:38:24:bb:
+                    2b:45:c7:79:23:7a:7f:0c:6b:25:d3:ce:e1:3f:e8:
+                    68:6c:31:7a:df:88:49:6d:a3:7e:22:24:08:3d:e1:
+                    6c:87:dd:34:77:d2:a5:eb:f7:e6:74:b9:e2:5f:e4:
+                    ad:49:e1:c0:b4:8f:d9:b5:ac:2d:7b:ba:22:64:8e:
+                    b7:c1:11:11:f1:e1:1f:b9:3e:29:b1:61:9b:8a:1c:
+                    2e:d4:e4:e6:10:5a:5d:e1:f9:1e:54:7b:13:79:dd:
+                    d9:ad:8b:23:c4:8d:a5:8b:f5:17:eb:99:96:5d:c6:
+                    8d:b4:af:8b:4c:2f:08:4d:37:c3:bf:6d:68:99:c4:
+                    f7:47:cc:5d:44:e7:6e:f2:64:b3:7d:bb:9b:c7:e1:
+                    27:cf:73:8d:b2:e2:88:19:6c:bb:6e:cd:4a:0a:79:
+                    a8:7b:9d:c3:b0:59:93:51:20:a1:d8:a2:0f:e5:62:
+                    76:17:b3:bb:aa:bc:3a:73:e7:f6:57:91:6a:cb:d3:
+                    7e:91:38:5e:88:57:e3:d8:3e:31:cd:dc:69:9a:74:
+                    bb:6e:62:c2:ab:5b:8c:f5:80:ff:b4:98:a2:87:15:
+                    72:38:77:76:dc:e2:d1:ac:2f:66:67:ae:c4:33:a8:
+                    86:94:af:41:b1:99:0d:5d:68:df:9a:ec:86:0f:0a:
+                    c9:67:fa:a1:7c:29:47:d3:f1:c1:3d:8a:d1:a4:12:
+                    a6:70:16:37:80:4f:d9:79:61:45:1c:07:77:68:60:
+                    4e:10:ec:94:dd:03:95:b1:37:cc:88:3d:60:cc:32:
+                    37:be:a5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                4A:91:C2:3E:A1:E9:04:C9:C0:9A:8B:CE:D4:37:4D:96:0E:74:FE:90
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication
+            X509v3 Key Usage:
+                Digital Signature, Key Encipherment
+            X509v3 Subject Alternative Name:
+                DNS:server
+    Signature Algorithm: sha256WithRSAEncryption
+         72:b4:75:02:f7:7b:e9:07:c6:79:1b:bb:11:e4:73:4a:b4:76:
+         1c:03:b9:58:8c:0a:80:f0:c6:8c:cc:2a:a7:c7:8c:57:a8:6e:
+         52:19:f0:b5:7c:0f:06:ab:2f:04:0e:99:32:b9:2c:b6:42:f0:
+         f5:5b:97:32:ce:bb:0c:ee:9f:b0:0b:bc:0b:c0:43:1d:7d:04:
+         b4:a1:cf:a0:aa:fe:f1:cc:b4:31:b3:bb:78:ed:0e:60:8d:37:
+         ea:48:a7:b4:2d:6d:64:6e:97:15:aa:e4:9b:b4:68:79:c8:3b:
+         ba:91:0b:db:cd:04:a3:aa:e4:69:59:06:ec:50:68:6d:0d:a6:
+         38:32:55:76:09:10:00:da:ac:a8:9e:ad:ad:95:8f:01:88:c9:
+         40:af:9a:5c:2d:17:34:81:6b:26:65:8a:e5:2a:15:79:13:2d:
+         ae:d8:03:16:6b:e9:b6:cd:f3:cb:d5:4d:5f:40:76:7a:99:99:
+         d5:2f:e8:a1:59:88:01:6b:a1:36:c0:53:dc:46:07:fd:ab:ab:
+         2a:5b:d3:d5:4c:84:c2:fb:48:16:80:80:01:f6:37:80:3a:54:
+         81:11:24:86:a6:a2:9a:73:06:5f:ca:24:8c:20:3a:40:6e:95:
+         8e:44:46:ef:60:bc:9d:11:ad:71:af:61:85:a6:e2:b4:49:c7:
+         fa:bb:ef:b5:c9:02:d2:a2:a5:3b:f6:46:03:dc:58:9f:ff:dc:
+         23:6b:b5:02:4c:1a:1a:80:99:6d:1a:fd:24:fc:32:83:f7:de:
+         fd:2b:b2:45:b7:3b:89:3c:49:0c:3d:0b:05:67:a5:95:00:3d:
+         cd:a7:0a:3b:b5:cd:02:10:09:de:ff:6c:6b:8b:aa:9d:e6:e9:
+         07:83:e2:dd:de:6d:bc:9e:fd:19:77:30:5d:67:12:c2:33:40:
+         0f:13:69:98:02:ef:05:b2:ad:ef:fb:73:15:57:70:46:83:32:
+         a9:05:4d:31:06:3d:44:93:88:69:de:9a:67:b4:6b:b7:0d:6b:
+         69:24:8b:62:52:f7:85:66:8f:84:2d:c0:a7:ff:33:37:7c:f3:
+         d1:1f:8c:b6:16:a3:98:db:6e:aa:e5:eb:d8:ed:06:31:19:ba:
+         01:f1:e6:3e:bc:78:ec:6e:b4:af:6c:8a:49:0f:ff:5a:f0:00:
+         88:d8:66:af:d6:49:31:b5:54:ce:be:07:59:46:bb:67:73:4b:
+         b8:ec:be:16:04:ed:fe:75:57:21:d6:d5:7b:cc:d0:7c:bd:91:
+         d3:6e:61:72:04:30:24:45:0a:0d:16:b6:35:94:49:02:14:8d:
+         2d:1d:71:42:13:9a:02:1e:3c:31:05:b4:76:5b:dd:ff:bb:db:
+         f4:31:b7:47:bb:54:f8:27
+-----BEGIN CERTIFICATE-----
+MIIFYjCCA0qgAwIBAgIRAJeAxmu1hIGzK/ZWVdpnTcgwDQYJKoZIhvcNAQELBQAw
+EzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMjUxMDAyMTE0
+NTEyWjARMQ8wDQYDVQQDDAZzZXJ2ZXIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+ggIKAoICAQC+9+4VvLbhBCg+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzp
+dSdVJDn87pLR2t7iXwFQtq5SGnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV
+0SgttwhOoGT7xrTii2FoTnJyzNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWY
+nkg8BJfNozaSFRKkv0bqlTcMbwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2Lq
+onkBedBYqix/iRS8PobAXlisWMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8M
+ayXTzuE/6GhsMXrfiElto34iJAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17
+uiJkjrfBERHx4R+5PimxYZuKHC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZd
+xo20r4tMLwhNN8O/bWiZxPdHzF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7
+ncOwWZNRIKHYog/lYnYXs7uqvDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKr
+W4z1gP+0mKKHFXI4d3bc4tGsL2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT
+8cE9itGkEqZwFjeAT9l5YUUcB3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABo4Gy
+MIGvMAkGA1UdEwQCMAAwHQYDVR0OBBYEFEqRwj6h6QTJwJqLztQ3TZYOdP6QME4G
+A1UdIwRHMEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhD
+aGFuZ2VNZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwEwYDVR0lBAwwCgYIKwYBBQUH
+AwEwCwYDVR0PBAQDAgWgMBEGA1UdEQQKMAiCBnNlcnZlcjANBgkqhkiG9w0BAQsF
+AAOCAgEAcrR1Avd76QfGeRu7EeRzSrR2HAO5WIwKgPDGjMwqp8eMV6huUhnwtXwP
+BqsvBA6ZMrkstkLw9VuXMs67DO6fsAu8C8BDHX0EtKHPoKr+8cy0MbO7eO0OYI03
+6kintC1tZG6XFarkm7Roecg7upEL280Eo6rkaVkG7FBobQ2mODJVdgkQANqsqJ6t
+rZWPAYjJQK+aXC0XNIFrJmWK5SoVeRMtrtgDFmvpts3zy9VNX0B2epmZ1S/ooVmI
+AWuhNsBT3EYH/aurKlvT1UyEwvtIFoCAAfY3gDpUgREkhqaimnMGX8okjCA6QG6V
+jkRG72C8nRGtca9hhabitEnH+rvvtckC0qKlO/ZGA9xYn//cI2u1AkwaGoCZbRr9
+JPwyg/fe/SuyRbc7iTxJDD0LBWellQA9zacKO7XNAhAJ3v9sa4uqnebpB4Pi3d5t
+vJ79GXcwXWcSwjNADxNpmALvBbKt7/tzFVdwRoMyqQVNMQY9RJOIad6aZ7Rrtw1r
+aSSLYlL3hWaPhC3Ap/8zN3zz0R+MthajmNtuquXr2O0GMRm6AfHmPrx47G60r2yK
+SQ//WvAAiNhmr9ZJMbVUzr4HWUa7Z3NLuOy+FgTt/nVXIdbVe8zQfL2R025hcgQw
+JEUKDRa2NZRJAhSNLR1xQhOaAh48MQW0dlvd/7vb9DG3R7tU+Cc=
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQC+9+4VvLbhBCg+
+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzpdSdVJDn87pLR2t7iXwFQtq5S
+GnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV0SgttwhOoGT7xrTii2FoTnJy
+zNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWYnkg8BJfNozaSFRKkv0bqlTcM
+bwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2LqonkBedBYqix/iRS8PobAXlis
+WMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8MayXTzuE/6GhsMXrfiElto34i
+JAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17uiJkjrfBERHx4R+5PimxYZuK
+HC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZdxo20r4tMLwhNN8O/bWiZxPdH
+zF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7ncOwWZNRIKHYog/lYnYXs7uq
+vDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKrW4z1gP+0mKKHFXI4d3bc4tGs
+L2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT8cE9itGkEqZwFjeAT9l5YUUc
+B3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABAoICAAnfT1OYWevwBxSQXg+JJZ2U
+BRAls9RZ4eSvBSqA+ITD0oJKgM+B15nKEKp6IPVOcBChO/x/5NWDXCeqbrR8rgIs
+3EnCtT/NYsxhS5fgw3ONUfnQa8Gvg+bw1R7n42oNKKtLbnZ3tiVqSMhehr78bi7V
+vNIUEnp2oMbbtXzPo5GxlT/TkyalEd698AYKRr6+vUd4B2q06Lmf1SSzaNNZJVFP
++mj5aJ/+h1up3iUh1gOBGM7gkavEZiyzEYZeAcNTqNE/CO9iXBz9w5/FRs+UuzBz
+29P//tDTyciMCX/8EcL0WhxVX5HR91dxApecjlB7d0qAlFWR+hnM5exl6HcqfC3C
++Uhi5IC+gZjD2KCcHDr9e5WqQ6cu8TeMnoyuHInIV9kUL3Bn1ArOU1dmGS78soeE
+GpqGCRc9Imh8jxs1AVyj9wGzpfuRS8OBpfR5MIlcFwSlZO/6dnJSaF2BH1jnKgBG
+Xn9MvjfHTU/EhLTteXrAJlqQr4e/uAK5QCESFNXLvC0r3qord6b9Y0zHR63SpESJ
+WVUIF9L2fIh0Z4CutPegcbEyWLaaAT4njyR4uCI78g77kK+PGi2NM65Mk+wKt975
+m3Qh4/cNv1ews4h+RflayWC9kiiRVzDHJGTy63k5gdplqrW2rb8gK3ZQaT2gQp9u
+gjKIIFGyi+EIDSukHNdRAoIBAQDuGvE9k1lSvoPgSusogMk7PWTiZbn8MwlEFueM
+ZJk9k8dMSkqF1k5BXG9lHcWuFl2invgTiFJIF7ML0GDsFJR+CzCDsanSGdjyKfGM
+HzHAc7UPAJYBXPX1rxTAhGSirKjArcqYUX3ZGGaTo1yZrsbbarInUhWWNKFBdaQ+
++L3oClGt3GZx7hdxapI/3gnkLvG/C5hWWetLONZAxY6jwJJSA/p2Fx93SlWOtrmT
+KRbM/p8m6sHtsXcBnYTueqWYpJ2mnBIB+Svf5acqQ2Xf8kAIw4Vw9u7a15OlIDGF
+ouWhtSkL4s0YfZjlXswOPZDlF3eT2ilf+OIjv5kEcLdDKOojAoIBAQDNUhfys2TH
+b1NFsIH6X1jtWHUEGOYIM/y/75Vw2pGLb40cMxVPtzsNCvz8id/sCuvx6yUWlBlN
+wjpa+7dOA+FgoXwv1iVsQm1zQlrt2VKaEy29C0tRkSwOjNC0bz1409wzYNnh5Bdx
+KJDvSz9zlefAryJGTSgGOothOjnguzoEJ6DxfkxNyWbxceBgN8JljDhc9dcybKdD
+Uxy2GflXhZvZfCtTbYfWoIV+dTYyZt2QE4PEPXrJHGUFE9ncGynbzAn1Cc/zGBeT
+zFNoYOCWNr7ueRNHQYMRZ1N3dYRdZ9th5mdqqa1eY5lP4PyQYZV6lwmyEfitXwNz
+vhS0sO+pNAyXAoIBAB9OiZOoESGRDTPrhdnwfQT+AIrIB1lCuKAsRsut2nw/NwAv
+8HaChA2SAs+Px5MpO6yLLGEdFnyGKTOPdX71AcVE4V8feA24+k50916OJ3N/gzny
+wMZzG5/vIlJh1f2RqCqVb0LxzBNEYxBcdWt7kIf/EmebIl16lA1QU4U4HXgqCy1K
+AmpOfOSbt5kQL8rB5WVSN/h6oDZmxb0EfMnJIzQHc+IdDjUYIAHAwsu3pljTzcdH
+LLJ9GAGtXXIhzC4yzsu+T5vU0FEDGCS1ceqtJoBAfQYqYaOCntYiUoCYt4q4kCoQ
+6xiiQv09pqTksW191WoqUDBfQBSlN5Be5am98nMCggEAIzEb+7R15J0XN82uKZzo
+IB5WSDKAUw2eF8PX6HT+F1kyZY/36ibszyp//EUhhVLF6Dw2qi0OPT66Q9f7LjsK
+CUcEgyqAVZL5MZVBAp2KQ/BfmZRy/3MTixbluteKQMiHaKMEFWzD+9hJJ0rNgGFE
+TMl35XbaEl88fpi9TOCqbAXi1yGfsIGBzIaJP9Su1Dr5ei2FChaHgMmhFTFUhITZ
+FqjqwCz46HexCeDLPk5VUZmWry8eeZQNWJZzc/+P6CWL210oMHGDsQiHj09zjyup
+BDTqcf8vmO8N5l7VJjFj797PAQA+P/xwTbmxcInZVh7HQadE6WpsrAz7fZEKMwVB
+1wKCAQEA3oqXI9bGGoXFjydUiNMZbuHdIDQCa9t7iDb+J+NAiA7GI8W8DlFYrUST
+S/CoBey/WOW9jPT/A8EBnp8RmPtAJH88qklbqh/YCoKyKZrgqT5IGysRLWwDFrGT
+QoOvR1a6SaVMLskmYUCkl8Yz8sZS58X50ahxx5TB0I3xsoCmnMZt+cd2C/VXwhFz
+jCiEZIuQlSgQFW4LOFrxrXmI+MDOBWu4zvkztWOnTe+BNgrxndGVI6sdFGzWeNQx
+dQ9imn0UqGSkgnJEj7Lq67ey8Cuu6yYWexKI0N9UOcyL4FgaEdWiJ0t5KY6NElGI
+0jrZX7pwVf/pvbKW2zVm6nXjWJ/JFw==
+-----END PRIVATE KEY-----
+</key>
+<dh>
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEAqJI9Luwkfy0E95gqZyq031Fa1rUCW5aBoppgm4YHxGUL+fUQzveF
+U2+W5xzmZuxhyoN0PVqlPXoMi0xGyTW4ga8qMaIHDqQ/V8RNxQYJ+GEEiC46/2u9
+Co/HbGX9YXMm5nnNEtHepAHcJiRB6QbCjzVm06x5QfWifj/yTm9ycVfJXhQJiOkD
+j4y4vJbgrmIKWX8Nxj4Q8dCAJzZ2gFvMnW9XcbS9SYbyvS0DvoQG3gPTGcopv7x1
+NiOhrxcTcMjwi/2z6kxG0MJEZ1HOJ2xTtRReUGXkL0lhbVTzkX4V6ihWK4MZYqe+
+ozy/0gbPAB4dT1QNeSRXPOi9f81Oed0SoC83P0oiq3JRQq2g7aS9OiwqlRPnVnvH
+q7Uko6+nv8XLbANgbdLXc8I3K78TSedwofxI/atxKncEic0fHV5ai2IdEWt22qxj
+iWVyaiHlWtMosZvuepSPn3cAmfuj0dVPNiRoG97neN8XIOaVZNGmNnI4yM0JEA1h
+Ef4Lh4YpDdqk4Q/nC/zJev8PM1XC+Os1SsGH50YAn8q19TGzI26/Y4jWfqrHswsj
+6vF/lxDS5RRzLIqlEksm84MU1q0AFSe9FaW1NTtKR/PLO1QiSKr718BwzzrDNN9u
+KZJabQ9n1RgLSuMP9zk9A6GUPQ7cZ0fJchUPeuF8Cd7zAV7k4m0RA4MCAQI=
+-----END DH PARAMETERS-----
+</dh>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.4.4-alpine-3.7/Dockerfile
+++ b/variants/2.4.4-alpine-3.7/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.7
+
+RUN apk add --no-cache openvpn~=2.4.4 iptables
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/2.4.4-alpine-3.7/docker-compose.yml
+++ b/variants/2.4.4-alpine-3.7/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '2.1'
+services:
+  openvpn-server:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
+      - NAT_MASQUERADE=1
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/server.conf:/etc/openvpn/server.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    ports:
+      - 1194:1194/udp
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped

--- a/variants/2.4.4-alpine-3.7/docker-entrypoint.sh
+++ b/variants/2.4.4-alpine-3.7/docker-entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+# Env vars
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
+OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
+NAT=${NAT:-1}
+NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
+CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    echo "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
+
+# If no args are passed, run the entrypoint. If a flag is passed, run openvpn directly. Else, run the passed command
+if [ "$#" -eq 0 ]; then
+    # Provision
+    echo "Provisioning tun device"
+    mkdir -p /dev/net
+    if [ ! -c /dev/net/tun ]; then
+        mknod /dev/net/tun c 10 200
+    fi
+    if [ -f "$CUSTOM_FIREWALL_SCRIPT" ]; then
+        echo "Executing custom firewall script: $CUSTOM_FIREWALL_SCRIPT"
+        . "$CUSTOM_FIREWALL_SCRIPT"
+    else
+        echo "Not executing custom firewall script $CUSTOM_FIREWALL_SCRIPT because it does not exist"
+    fi
+    if [ "$NAT" = 1 ]; then
+        echo "NAT is enabled"
+        echo "Provisioning NAT iptables rules"
+        echo "NAT_INTERFACE: $NAT_INTERFACE"
+        if [ "$NAT_MASQUERADE" = 1 ]; then
+            echo "NAT_MASQUERADE is enabled"
+            iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+            if [ -n "$OPENVPN_ROUTES" ]; then
+                echo "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+                for r in $OPENVPN_ROUTES; do
+                    iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+                done
+            else
+                echo "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+            fi
+        else
+            echo "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
+        fi
+    else
+        echo "NAT is disabled."
+        echo "Not adding NAT iptables rules"
+    fi
+
+    echo "Listing iptables rules:"
+    iptables -L -nv
+    echo "Listing iptables NAT rules:"
+    iptables -L -nv -t nat
+
+    # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
+    set openvpn --cd /etc/openvpn --config "$OPENVPN_CONFIG_FILE"
+    echo "openvpn command line: $@"
+    exec "$@"
+elif [ "$#" -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    echo "openvpn command line: $@"
+    exec openvpn "$@"
+fi
+
+exec "$@"

--- a/variants/2.4.4-alpine-3.7/openvpn/client.conf
+++ b/variants/2.4.4-alpine-3.7/openvpn/client.conf
@@ -1,0 +1,258 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/client.conf
+client
+dev tun
+proto udp
+remote openvpn-server 1194
+remote-random
+# Push all traffic into the tunnel
+;redirect-gateway def1 bypass-dhcp
+resolv-retry infinite
+nobind
+user nobody
+group nobody
+persist-key
+persist-tun
+remote-cert-tls server
+cipher AES-256-CBC
+auth SHA512
+comp-lzo
+verb 4
+key-direction 1
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:4e:3e:ee:0c:a0:be:17:77:36:7e:3e:48:bf:5a:f3
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=client-01
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:b3:ef:25:0f:86:77:8e:9f:a4:42:02:f0:19:0e:
+                    20:0e:93:5e:67:78:17:99:a9:cd:06:84:fe:c1:ed:
+                    5b:c9:96:d1:82:ef:5f:a5:95:d7:de:99:97:84:cc:
+                    a8:28:13:69:2f:41:7a:d4:f0:ac:a7:a3:10:8a:31:
+                    c6:aa:14:dd:d0:5d:15:51:2c:e9:5e:3e:fe:f0:1c:
+                    d7:62:07:f7:fb:01:93:22:8f:4b:72:77:76:8a:14:
+                    fe:26:52:59:c8:59:b0:01:b6:cb:7a:2d:ba:0d:35:
+                    a2:8c:42:97:18:54:45:58:f1:69:ff:3b:ce:fd:71:
+                    a5:13:42:82:ca:e2:25:43:61:d6:34:1f:f6:f3:36:
+                    7f:c9:7d:a4:e2:83:f1:8f:b7:2d:cd:7f:cf:1a:90:
+                    a4:86:ce:c0:6b:36:b3:9e:90:d0:60:5c:ec:ac:70:
+                    f7:32:16:59:20:1f:27:a5:3c:00:a0:9b:63:30:41:
+                    a5:d3:63:37:9d:10:f7:f6:53:45:54:57:70:7e:06:
+                    a6:01:32:38:2c:2d:d1:11:4c:3f:57:25:5a:2c:2c:
+                    06:a0:20:bb:c0:95:fd:44:a8:0d:3a:b0:c9:a3:b2:
+                    77:ce:f7:f0:f5:c8:1c:a7:74:ba:b9:83:0b:3c:56:
+                    6f:18:cb:df:39:77:3a:69:18:57:be:48:7e:ab:2a:
+                    21:2d:b0:eb:4c:26:ae:93:f2:d9:0d:29:01:b8:2c:
+                    0b:5a:ec:8a:c0:fd:5d:1c:a7:6f:31:29:5d:5c:35:
+                    cd:0e:e0:97:86:07:af:5e:69:8e:e7:e1:f0:78:21:
+                    f3:15:c6:35:cd:e6:4b:65:d5:17:0b:87:6e:ea:39:
+                    44:96:ab:bc:fc:ee:27:85:fe:10:c4:77:96:25:cd:
+                    9a:66:ee:e4:36:fb:f0:c8:90:62:de:6d:f6:8c:19:
+                    76:c6:6d:c3:9c:a4:9f:80:ec:39:79:ba:32:36:b2:
+                    7d:93:3c:dc:58:c5:13:34:35:8a:7e:cb:cc:f0:9a:
+                    bb:39:dd:ca:bc:cf:c7:7a:8f:9b:60:f1:a8:e6:e4:
+                    41:62:82:cd:cc:d2:81:06:c1:5b:82:0c:49:88:e6:
+                    bd:39:b2:06:82:a0:fb:55:ba:fd:de:57:2f:40:84:
+                    07:b8:38:9a:49:6e:38:49:c0:b9:26:f7:7e:a9:9a:
+                    18:b3:27:b9:d9:b3:fb:7f:6d:9e:68:58:94:f7:b1:
+                    21:b5:ee:59:b0:7f:fc:0f:ab:00:c2:8e:94:34:09:
+                    c3:45:dd:4c:79:03:b8:bf:ce:55:8f:6e:6d:c9:ff:
+                    4c:5b:da:fb:eb:70:bd:c9:37:68:6e:03:e0:db:2f:
+                    6e:db:6c:d4:f0:1f:01:43:42:6e:f6:31:4b:8d:fb:
+                    21:1e:77
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                23:46:34:1C:74:3B:D8:21:40:4D:81:B3:58:9F:57:CB:0C:5E:90:FB
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+    Signature Algorithm: sha256WithRSAEncryption
+         3c:80:ef:a8:a1:94:bc:12:33:6c:19:2e:44:44:6c:20:8e:69:
+         f6:b8:21:ad:4b:f7:14:d6:bf:c3:8d:b0:87:d1:e2:55:df:c0:
+         fd:03:31:82:8a:82:dd:68:3d:61:1f:c4:89:eb:e6:07:b0:89:
+         1d:19:8b:ee:57:9f:87:d8:a2:d8:fe:84:ad:f1:18:9c:b5:93:
+         a1:17:48:41:1e:f7:12:1e:50:46:b7:57:93:6e:d5:0f:d5:84:
+         a8:8e:74:4f:ab:8a:ae:40:64:8a:a8:57:32:75:b6:82:20:10:
+         be:ab:70:0c:96:c7:30:f4:69:c7:c9:24:db:3a:bc:40:eb:ac:
+         ee:04:f3:58:4a:09:6e:42:01:b4:a5:77:e5:2b:01:05:c1:5c:
+         08:59:0b:e3:a9:7a:b4:3e:f9:41:8d:2b:e6:8e:40:27:07:07:
+         0d:b0:03:ba:c9:d2:cd:dd:3c:9a:7e:20:66:bb:7f:4f:9d:fc:
+         37:16:88:84:a1:26:6a:91:43:d1:47:82:cb:e1:84:d4:03:93:
+         ec:8d:14:ce:2c:c8:fc:96:f8:28:d5:cb:89:c8:84:ee:8a:54:
+         8e:3c:12:86:10:73:78:5c:b8:a5:7d:99:94:b1:e1:f9:18:ed:
+         4b:2f:ae:8d:d4:9b:bc:20:21:d3:13:ed:07:15:70:dc:d1:1f:
+         58:22:fc:0e:5a:49:4e:6f:c1:99:9d:de:71:4e:62:7d:ad:d3:
+         2e:c3:ca:3f:db:cf:f3:46:aa:95:1f:99:1c:81:f8:15:5a:a1:
+         30:f7:7b:4a:e1:8a:fa:8b:a4:92:6d:11:e3:4c:f5:2b:b9:a3:
+         6d:a4:07:93:cb:28:f7:06:c1:e8:1b:1e:c5:aa:76:51:7e:1b:
+         a7:fe:db:9b:d4:23:d1:2a:16:52:ed:d1:2c:55:2b:cd:db:73:
+         fa:20:1a:18:47:af:90:50:0c:fe:1b:0d:f6:06:ec:33:1f:8e:
+         6f:f2:9a:d0:49:88:cb:a0:8c:8a:60:54:8e:d0:c1:59:ad:e6:
+         6e:6a:3e:e4:3b:b4:1b:01:8e:81:a4:f2:21:94:d1:a7:5e:e8:
+         1a:14:af:f1:46:5d:6a:ad:9d:06:02:84:58:96:b2:e6:f8:02:
+         5f:ce:ed:87:54:b5:f9:b6:62:97:51:b2:88:05:49:de:fd:56:
+         d1:67:e5:59:78:31:82:36:17:ce:07:62:81:5c:19:82:48:22:
+         88:15:ea:d9:fc:1e:c3:ee:05:a5:ec:e9:ca:69:b5:2a:7e:79:
+         ed:aa:6e:3f:b5:45:75:0b:d4:27:e4:4c:88:04:e0:06:36:5e:
+         41:37:b0:f5:44:80:58:86:dc:c1:be:82:62:fe:a8:2c:6c:ca:
+         6a:f8:dd:fd:85:df:5a:41
+-----BEGIN CERTIFICATE-----
+MIIFUTCCAzmgAwIBAgIQDU4+7gygvhd3Nn4+SL9a8zANBgkqhkiG9w0BAQsFADAT
+MREwDwYDVQQDDAhDaGFuZ2VNZTAeFw0yMzA2MzAxMTQ1MTJaFw0yNTEwMDIxMTQ1
+MTJaMBQxEjAQBgNVBAMMCWNsaWVudC0wMTCCAiIwDQYJKoZIhvcNAQEBBQADggIP
+ADCCAgoCggIBALPvJQ+Gd46fpEIC8BkOIA6TXmd4F5mpzQaE/sHtW8mW0YLvX6WV
+196Zl4TMqCgTaS9BetTwrKejEIoxxqoU3dBdFVEs6V4+/vAc12IH9/sBkyKPS3J3
+dooU/iZSWchZsAG2y3otug01ooxClxhURVjxaf87zv1xpRNCgsriJUNh1jQf9vM2
+f8l9pOKD8Y+3Lc1/zxqQpIbOwGs2s56Q0GBc7Kxw9zIWWSAfJ6U8AKCbYzBBpdNj
+N50Q9/ZTRVRXcH4GpgEyOCwt0RFMP1clWiwsBqAgu8CV/USoDTqwyaOyd8738PXI
+HKd0urmDCzxWbxjL3zl3OmkYV75IfqsqIS2w60wmrpPy2Q0pAbgsC1rsisD9XRyn
+bzEpXVw1zQ7gl4YHr15pjufh8Hgh8xXGNc3mS2XVFwuHbuo5RJarvPzuJ4X+EMR3
+liXNmmbu5Db78MiQYt5t9owZdsZtw5ykn4DsOXm6MjayfZM83FjFEzQ1in7LzPCa
+uzndyrzPx3qPm2DxqObkQWKCzczSgQbBW4IMSYjmvTmyBoKg+1W6/d5XL0CEB7g4
+mkluOEnAuSb3fqmaGLMnudmz+39tnmhYlPexIbXuWbB//A+rAMKOlDQJw0XdTHkD
+uL/OVY9ubcn/TFva++twvck3aG4D4Nsvbtts1PAfAUNCbvYxS437IR53AgMBAAGj
+gZ8wgZwwCQYDVR0TBAIwADAdBgNVHQ4EFgQUI0Y0HHQ72CFATYGzWJ9XywxekPsw
+TgYDVR0jBEcwRYAUmBuw7bvaYZi1OnrIxE4ycKX4qQehF6QVMBMxETAPBgNVBAMM
+CENoYW5nZU1lghQRFLv/ZzUIweAY3+3bxHLwDm1FLDATBgNVHSUEDDAKBggrBgEF
+BQcDAjALBgNVHQ8EBAMCB4AwDQYJKoZIhvcNAQELBQADggIBADyA76ihlLwSM2wZ
+LkREbCCOafa4Ia1L9xTWv8ONsIfR4lXfwP0DMYKKgt1oPWEfxInr5gewiR0Zi+5X
+n4fYotj+hK3xGJy1k6EXSEEe9xIeUEa3V5Nu1Q/VhKiOdE+riq5AZIqoVzJ1toIg
+EL6rcAyWxzD0acfJJNs6vEDrrO4E81hKCW5CAbSld+UrAQXBXAhZC+OperQ++UGN
+K+aOQCcHBw2wA7rJ0s3dPJp+IGa7f0+d/DcWiIShJmqRQ9FHgsvhhNQDk+yNFM4s
+yPyW+CjVy4nIhO6KVI48EoYQc3hcuKV9mZSx4fkY7Usvro3Um7wgIdMT7QcVcNzR
+H1gi/A5aSU5vwZmd3nFOYn2t0y7Dyj/bz/NGqpUfmRyB+BVaoTD3e0rhivqLpJJt
+EeNM9Su5o22kB5PLKPcGwegbHsWqdlF+G6f+25vUI9EqFlLt0SxVK83bc/ogGhhH
+r5BQDP4bDfYG7DMfjm/ymtBJiMugjIpgVI7QwVmt5m5qPuQ7tBsBjoGk8iGU0ade
+6BoUr/FGXWqtnQYChFiWsub4Al/O7YdUtfm2YpdRsogFSd79VtFn5Vl4MYI2F84H
+YoFcGYJIIogV6tn8HsPuBaXs6cpptSp+ee2qbj+1RXUL1CfkTIgE4AY2XkE3sPVE
+gFiG3MG+gmL+qCxsymr43f2F31pB
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQCz7yUPhneOn6RC
+AvAZDiAOk15neBeZqc0GhP7B7VvJltGC71+lldfemZeEzKgoE2kvQXrU8KynoxCK
+McaqFN3QXRVRLOlePv7wHNdiB/f7AZMij0tyd3aKFP4mUlnIWbABtst6LboNNaKM
+QpcYVEVY8Wn/O879caUTQoLK4iVDYdY0H/bzNn/JfaTig/GPty3Nf88akKSGzsBr
+NrOekNBgXOyscPcyFlkgHyelPACgm2MwQaXTYzedEPf2U0VUV3B+BqYBMjgsLdER
+TD9XJVosLAagILvAlf1EqA06sMmjsnfO9/D1yByndLq5gws8Vm8Yy985dzppGFe+
+SH6rKiEtsOtMJq6T8tkNKQG4LAta7IrA/V0cp28xKV1cNc0O4JeGB69eaY7n4fB4
+IfMVxjXN5ktl1RcLh27qOUSWq7z87ieF/hDEd5YlzZpm7uQ2+/DIkGLebfaMGXbG
+bcOcpJ+A7Dl5ujI2sn2TPNxYxRM0NYp+y8zwmrs53cq8z8d6j5tg8ajm5EFigs3M
+0oEGwVuCDEmI5r05sgaCoPtVuv3eVy9AhAe4OJpJbjhJwLkm936pmhizJ7nZs/t/
+bZ5oWJT3sSG17lmwf/wPqwDCjpQ0CcNF3Ux5A7i/zlWPbm3J/0xb2vvrcL3JN2hu
+A+DbL27bbNTwHwFDQm72MUuN+yEedwIDAQABAoICAAuYKlwwvv16vfve8pe6uEgY
+KOoj6+lj7qkv4raeU97OkBuOzyv9VtaqMQBGq8NBVPLNlluoUofO0x8EjBejlpN5
+nAkKCtOe3ZCdWyee+dS7yj5c23C5z/Kf3ayce9qUJOpHXB84WRfGz/2XwOK5c2qC
+y+C9et4L96YhEAqAvgP0hvf+40vSxDM4nGpYNDWdiR8H0FGW5nMlWXLPKI3cKQE8
+m6eU8+jPVdjjCQv1rNisipyubkAL0aaWVFQUE5CWvdHxHbtQABygqyshLaew6XmV
+MKwaz95eC97jsU6J28RnmJ7GjUlZJreHpwyTLCMsMqZ3ZJ/wVdw1zFmflEH1SgPq
+/JNd0OONKm8x7nORX9dHEn33Imfyg2jI6tzVx1oAmMWMb9hJ0XjkIyzjfHTPi5KW
+pM3pTUUn6ee4P1T4ReBlatiw2TFgAd18/9gSIaSlENEjslJGQ6/Ndt9O7UNHgwth
+ZNtPovjNLqUobHGXlmwg3haeBshn9iPcjdksAjgtjEyowzq7IpiSxQezXNcMezGM
+Y9UL5Qc/yjQ3t+Vu94Jmnu0TT3lHGWa3zSgI6L+UdBiIsLF6P5YQVloYOYWE3q/n
+HTaORoZlsRKfMIUHmhrZ1keJ4VGqLruSpQHobh3Cfb/xzgOEB3nSwhIK3l2FhSiR
+N9jb0r7kMElO+xlm7NChAoIBAQDllnlfyWnTBGog8+T9eJiODuBfdozy2vCZO8nc
+vp11NC7fLh5NXR16Ju6I+dcXDhPdoOG8H/DScjer82kEINrY7Wb4swNd01cLCg+/
+xVNe9iiLl4Q4m/QOI6ZOUbOfJjH9R8J4Bh/FzR1MXtVktgtsd6JB3zv6V246zDjy
+eMnOImwoj6TH/3hI/g2s5i3GoaC7CK+XjpdfZbVAX5+mnpZxBbOqXt7an1IzYHhx
+hQO8uo/9b2IDxMrWWn80mGj9Fw5AdK1Ef3eMtbyG6iOIR92UEo9ZwlZ9Tang58Sa
+7IFHZko/HcCrS92Hl9YcnYmjG0GDeFl4des+IcVz0AHDhe6RAoIBAQDIolXgCYO3
+zo2MtoBTCr+GcluT4DD16ALz7wd8/jXFqmD3UWCAeaS5IsTno1PmuIpvB7dvwz8B
+6SOpE//J/bECDmhE18UHYOAqkXzzuuEGMCP1TuaCWBq7kWV8GVTRcSGQDxLyf/Yu
+IdxiPQMaCxi0Ffv+aq27Nii1IyV8tyDL3skyGZeQJNW2xjNkngkXsB5Tp7H7tA0G
+lSmld1Rtq2XWcRnHQh9ZVP+FxwkjBkdoX0oAASVQwHsy9Q4hZ5ykxPkIGULj3Hw5
+zvG1RAM5B4GQegK0OfYuX5Ullrz6a/6p/FnGLvRkZGlHML/bHTmrr8ywSvF63Gkd
+oU0nqjPFQ1CHAoIBACoFR4PDno3TwgTz/tZxqyJdEK4ISbXtYpn5OnIfpTwdZ/LL
+QxqPz2RbGc+SQs7icbpfxtEi23X5F71uGKt7w/JuSSl9wkD6/HR1y/oiiKbZ0QPz
+oGyoBpxL5BVzmLepSv77kllbbZdLenBO7ym2tBKPNvBthlHEjNVQKaAfgXgsDrXB
+zLwaQw7BCQm7O2eej4eMCG9p1sTMHceBePwLDKf1DjRBlvJWtLnYj1LfsJZrYw1U
+xJDCBQoEmEGtH5IrFR2w/UGLPvtPDAl5czVvSdvfJcOc8S2P+GbEpNRiMys5Sp+Q
+t4HiqdI2dSbZoqZqx6vjbCTDGGJP1g7jZF8/9TECggEAXOXVj2O4an4oSnQiXNEI
+N29x+bl/0gy4eUw/El/+c+Tc+wbiAPrSC6sOsxaL/bOK3bgb9pLX9MGHcn1BHbzq
+ncIgA2hI4Y64nN06lvv7v0rBC4+Z6dZzok/DRr/P5x5T5Qklw8T+LwQcsBwB+KgU
+qyXWxUmN4bZFCQIaFHISrHMeg6UX6XU0w2loWHlYSnCQyjlGjv4iXd7pJqVnIVSQ
+VceOoRV7wHg7zCyJjX8Vxzz/3ZqqNYa6RLD09wCrphtSF67iqvDnUDkC7+Rq/Zf9
+JPFpmRuRYo19WKdAH0+r3fdrdfk9zdI0cPMgkosordc7lpFM2I9/2GlceTY0vGzb
+twKCAQEArUbkiwUZFjdjAbKS2m0uPJyytB8bZ335szcoMUV665hzU9EJPcWeVY0L
+1FSRu/cig+ZCmpUEc/4JhJVKLEEXgC3BgfHGNHi5PIuvssMT/fJJ9InQe8n4Zq0Q
+eZbrfAewrdH3bTpEf6AxIsrMioLsUQSV12iRQ7olsEP9t5HqRKqwhAnqp+q33XT3
+L++8IcaaEQ3S/sBb23pY+VSWQfKGFVQES+P7yKeNHjBNQpJTPOdM9iLtvriUmNdO
+Gy5HOpLgd10DzXBOI7CgqzFm69Bqk+WFZXGVd9T/Ku69B8XfshoRChGbgHbbEG70
+0xT4AQEuygYVBbUrIerZFpDD+Tw7ww==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.4.4-alpine-3.7/openvpn/firewall.sh
+++ b/variants/2.4.4-alpine-3.7/openvpn/firewall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# This iptables script to controlling traffic in the openvpn tunnel.
+# In this example, clients can only perform DNS, HTTP and HTTPS requests to the world.
+
+# Drop everything by default from tunnel to world
+iptables -P FORWARD DROP
+# Allow DNS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p udp -m udp --dport 53 -m conntrack --ctstate NEW -j ACCEPT
+# Allow HTTP and HTTPS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p tcp -m tcp -m conntrack --ctstate NEW -m multiport --dports 80,443 -j ACCEPT

--- a/variants/2.4.4-alpine-3.7/openvpn/server.conf
+++ b/variants/2.4.4-alpine-3.7/openvpn/server.conf
@@ -1,0 +1,280 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/server.conf
+port 1194
+proto udp
+dev tun
+server 10.8.0.0 255.255.255.0
+ifconfig-pool-persist tun-ipp.txt
+;client-config-dir ccd
+keepalive 10 120
+comp-lzo no
+max-clients 5
+user nobody
+group nogroup
+persist-key
+persist-tun
+status tun.status
+status-version 3
+;log-append server.log
+verb 4
+mute 20
+;duplicate-cn
+tls-version-min 1.2
+cipher AES-256-CBC
+auth SHA512
+key-direction 0
+;crl-verify crl.pem
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            97:80:c6:6b:b5:84:81:b3:2b:f6:56:55:da:67:4d:c8
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=server
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:be:f7:ee:15:bc:b6:e1:04:28:3e:38:6a:61:dd:
+                    ee:fa:61:85:9a:a7:be:44:22:52:b4:cf:7a:86:0e:
+                    21:ae:1e:2b:61:66:17:1f:54:dc:e9:75:27:55:24:
+                    39:fc:ee:92:d1:da:de:e2:5f:01:50:b6:ae:52:1a:
+                    79:6b:8d:56:0d:83:f6:d4:19:50:48:bc:cb:d8:69:
+                    c8:79:d4:ba:82:05:db:aa:58:12:4b:34:1b:15:d1:
+                    28:2d:b7:08:4e:a0:64:fb:c6:b4:e2:8b:61:68:4e:
+                    72:72:cc:da:a2:d8:cb:f5:6a:5d:13:b6:98:d3:0c:
+                    a3:05:7a:21:e3:f9:fb:de:89:be:37:ac:ce:4c:2e:
+                    95:98:9e:48:3c:04:97:cd:a3:36:92:15:12:a4:bf:
+                    46:ea:95:37:0c:6f:09:e1:51:f5:4e:13:9f:f5:68:
+                    65:0e:24:38:62:04:f8:f9:0c:06:72:c9:03:ed:5d:
+                    6f:40:3b:62:ea:a2:79:01:79:d0:58:aa:2c:7f:89:
+                    14:bc:3e:86:c0:5e:58:ac:58:c0:97:fe:65:57:46:
+                    bf:01:cc:d4:d7:64:d8:21:15:02:6b:6a:38:24:bb:
+                    2b:45:c7:79:23:7a:7f:0c:6b:25:d3:ce:e1:3f:e8:
+                    68:6c:31:7a:df:88:49:6d:a3:7e:22:24:08:3d:e1:
+                    6c:87:dd:34:77:d2:a5:eb:f7:e6:74:b9:e2:5f:e4:
+                    ad:49:e1:c0:b4:8f:d9:b5:ac:2d:7b:ba:22:64:8e:
+                    b7:c1:11:11:f1:e1:1f:b9:3e:29:b1:61:9b:8a:1c:
+                    2e:d4:e4:e6:10:5a:5d:e1:f9:1e:54:7b:13:79:dd:
+                    d9:ad:8b:23:c4:8d:a5:8b:f5:17:eb:99:96:5d:c6:
+                    8d:b4:af:8b:4c:2f:08:4d:37:c3:bf:6d:68:99:c4:
+                    f7:47:cc:5d:44:e7:6e:f2:64:b3:7d:bb:9b:c7:e1:
+                    27:cf:73:8d:b2:e2:88:19:6c:bb:6e:cd:4a:0a:79:
+                    a8:7b:9d:c3:b0:59:93:51:20:a1:d8:a2:0f:e5:62:
+                    76:17:b3:bb:aa:bc:3a:73:e7:f6:57:91:6a:cb:d3:
+                    7e:91:38:5e:88:57:e3:d8:3e:31:cd:dc:69:9a:74:
+                    bb:6e:62:c2:ab:5b:8c:f5:80:ff:b4:98:a2:87:15:
+                    72:38:77:76:dc:e2:d1:ac:2f:66:67:ae:c4:33:a8:
+                    86:94:af:41:b1:99:0d:5d:68:df:9a:ec:86:0f:0a:
+                    c9:67:fa:a1:7c:29:47:d3:f1:c1:3d:8a:d1:a4:12:
+                    a6:70:16:37:80:4f:d9:79:61:45:1c:07:77:68:60:
+                    4e:10:ec:94:dd:03:95:b1:37:cc:88:3d:60:cc:32:
+                    37:be:a5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                4A:91:C2:3E:A1:E9:04:C9:C0:9A:8B:CE:D4:37:4D:96:0E:74:FE:90
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication
+            X509v3 Key Usage:
+                Digital Signature, Key Encipherment
+            X509v3 Subject Alternative Name:
+                DNS:server
+    Signature Algorithm: sha256WithRSAEncryption
+         72:b4:75:02:f7:7b:e9:07:c6:79:1b:bb:11:e4:73:4a:b4:76:
+         1c:03:b9:58:8c:0a:80:f0:c6:8c:cc:2a:a7:c7:8c:57:a8:6e:
+         52:19:f0:b5:7c:0f:06:ab:2f:04:0e:99:32:b9:2c:b6:42:f0:
+         f5:5b:97:32:ce:bb:0c:ee:9f:b0:0b:bc:0b:c0:43:1d:7d:04:
+         b4:a1:cf:a0:aa:fe:f1:cc:b4:31:b3:bb:78:ed:0e:60:8d:37:
+         ea:48:a7:b4:2d:6d:64:6e:97:15:aa:e4:9b:b4:68:79:c8:3b:
+         ba:91:0b:db:cd:04:a3:aa:e4:69:59:06:ec:50:68:6d:0d:a6:
+         38:32:55:76:09:10:00:da:ac:a8:9e:ad:ad:95:8f:01:88:c9:
+         40:af:9a:5c:2d:17:34:81:6b:26:65:8a:e5:2a:15:79:13:2d:
+         ae:d8:03:16:6b:e9:b6:cd:f3:cb:d5:4d:5f:40:76:7a:99:99:
+         d5:2f:e8:a1:59:88:01:6b:a1:36:c0:53:dc:46:07:fd:ab:ab:
+         2a:5b:d3:d5:4c:84:c2:fb:48:16:80:80:01:f6:37:80:3a:54:
+         81:11:24:86:a6:a2:9a:73:06:5f:ca:24:8c:20:3a:40:6e:95:
+         8e:44:46:ef:60:bc:9d:11:ad:71:af:61:85:a6:e2:b4:49:c7:
+         fa:bb:ef:b5:c9:02:d2:a2:a5:3b:f6:46:03:dc:58:9f:ff:dc:
+         23:6b:b5:02:4c:1a:1a:80:99:6d:1a:fd:24:fc:32:83:f7:de:
+         fd:2b:b2:45:b7:3b:89:3c:49:0c:3d:0b:05:67:a5:95:00:3d:
+         cd:a7:0a:3b:b5:cd:02:10:09:de:ff:6c:6b:8b:aa:9d:e6:e9:
+         07:83:e2:dd:de:6d:bc:9e:fd:19:77:30:5d:67:12:c2:33:40:
+         0f:13:69:98:02:ef:05:b2:ad:ef:fb:73:15:57:70:46:83:32:
+         a9:05:4d:31:06:3d:44:93:88:69:de:9a:67:b4:6b:b7:0d:6b:
+         69:24:8b:62:52:f7:85:66:8f:84:2d:c0:a7:ff:33:37:7c:f3:
+         d1:1f:8c:b6:16:a3:98:db:6e:aa:e5:eb:d8:ed:06:31:19:ba:
+         01:f1:e6:3e:bc:78:ec:6e:b4:af:6c:8a:49:0f:ff:5a:f0:00:
+         88:d8:66:af:d6:49:31:b5:54:ce:be:07:59:46:bb:67:73:4b:
+         b8:ec:be:16:04:ed:fe:75:57:21:d6:d5:7b:cc:d0:7c:bd:91:
+         d3:6e:61:72:04:30:24:45:0a:0d:16:b6:35:94:49:02:14:8d:
+         2d:1d:71:42:13:9a:02:1e:3c:31:05:b4:76:5b:dd:ff:bb:db:
+         f4:31:b7:47:bb:54:f8:27
+-----BEGIN CERTIFICATE-----
+MIIFYjCCA0qgAwIBAgIRAJeAxmu1hIGzK/ZWVdpnTcgwDQYJKoZIhvcNAQELBQAw
+EzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMjUxMDAyMTE0
+NTEyWjARMQ8wDQYDVQQDDAZzZXJ2ZXIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+ggIKAoICAQC+9+4VvLbhBCg+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzp
+dSdVJDn87pLR2t7iXwFQtq5SGnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV
+0SgttwhOoGT7xrTii2FoTnJyzNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWY
+nkg8BJfNozaSFRKkv0bqlTcMbwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2Lq
+onkBedBYqix/iRS8PobAXlisWMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8M
+ayXTzuE/6GhsMXrfiElto34iJAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17
+uiJkjrfBERHx4R+5PimxYZuKHC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZd
+xo20r4tMLwhNN8O/bWiZxPdHzF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7
+ncOwWZNRIKHYog/lYnYXs7uqvDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKr
+W4z1gP+0mKKHFXI4d3bc4tGsL2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT
+8cE9itGkEqZwFjeAT9l5YUUcB3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABo4Gy
+MIGvMAkGA1UdEwQCMAAwHQYDVR0OBBYEFEqRwj6h6QTJwJqLztQ3TZYOdP6QME4G
+A1UdIwRHMEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhD
+aGFuZ2VNZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwEwYDVR0lBAwwCgYIKwYBBQUH
+AwEwCwYDVR0PBAQDAgWgMBEGA1UdEQQKMAiCBnNlcnZlcjANBgkqhkiG9w0BAQsF
+AAOCAgEAcrR1Avd76QfGeRu7EeRzSrR2HAO5WIwKgPDGjMwqp8eMV6huUhnwtXwP
+BqsvBA6ZMrkstkLw9VuXMs67DO6fsAu8C8BDHX0EtKHPoKr+8cy0MbO7eO0OYI03
+6kintC1tZG6XFarkm7Roecg7upEL280Eo6rkaVkG7FBobQ2mODJVdgkQANqsqJ6t
+rZWPAYjJQK+aXC0XNIFrJmWK5SoVeRMtrtgDFmvpts3zy9VNX0B2epmZ1S/ooVmI
+AWuhNsBT3EYH/aurKlvT1UyEwvtIFoCAAfY3gDpUgREkhqaimnMGX8okjCA6QG6V
+jkRG72C8nRGtca9hhabitEnH+rvvtckC0qKlO/ZGA9xYn//cI2u1AkwaGoCZbRr9
+JPwyg/fe/SuyRbc7iTxJDD0LBWellQA9zacKO7XNAhAJ3v9sa4uqnebpB4Pi3d5t
+vJ79GXcwXWcSwjNADxNpmALvBbKt7/tzFVdwRoMyqQVNMQY9RJOIad6aZ7Rrtw1r
+aSSLYlL3hWaPhC3Ap/8zN3zz0R+MthajmNtuquXr2O0GMRm6AfHmPrx47G60r2yK
+SQ//WvAAiNhmr9ZJMbVUzr4HWUa7Z3NLuOy+FgTt/nVXIdbVe8zQfL2R025hcgQw
+JEUKDRa2NZRJAhSNLR1xQhOaAh48MQW0dlvd/7vb9DG3R7tU+Cc=
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQC+9+4VvLbhBCg+
+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzpdSdVJDn87pLR2t7iXwFQtq5S
+GnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV0SgttwhOoGT7xrTii2FoTnJy
+zNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWYnkg8BJfNozaSFRKkv0bqlTcM
+bwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2LqonkBedBYqix/iRS8PobAXlis
+WMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8MayXTzuE/6GhsMXrfiElto34i
+JAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17uiJkjrfBERHx4R+5PimxYZuK
+HC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZdxo20r4tMLwhNN8O/bWiZxPdH
+zF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7ncOwWZNRIKHYog/lYnYXs7uq
+vDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKrW4z1gP+0mKKHFXI4d3bc4tGs
+L2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT8cE9itGkEqZwFjeAT9l5YUUc
+B3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABAoICAAnfT1OYWevwBxSQXg+JJZ2U
+BRAls9RZ4eSvBSqA+ITD0oJKgM+B15nKEKp6IPVOcBChO/x/5NWDXCeqbrR8rgIs
+3EnCtT/NYsxhS5fgw3ONUfnQa8Gvg+bw1R7n42oNKKtLbnZ3tiVqSMhehr78bi7V
+vNIUEnp2oMbbtXzPo5GxlT/TkyalEd698AYKRr6+vUd4B2q06Lmf1SSzaNNZJVFP
++mj5aJ/+h1up3iUh1gOBGM7gkavEZiyzEYZeAcNTqNE/CO9iXBz9w5/FRs+UuzBz
+29P//tDTyciMCX/8EcL0WhxVX5HR91dxApecjlB7d0qAlFWR+hnM5exl6HcqfC3C
++Uhi5IC+gZjD2KCcHDr9e5WqQ6cu8TeMnoyuHInIV9kUL3Bn1ArOU1dmGS78soeE
+GpqGCRc9Imh8jxs1AVyj9wGzpfuRS8OBpfR5MIlcFwSlZO/6dnJSaF2BH1jnKgBG
+Xn9MvjfHTU/EhLTteXrAJlqQr4e/uAK5QCESFNXLvC0r3qord6b9Y0zHR63SpESJ
+WVUIF9L2fIh0Z4CutPegcbEyWLaaAT4njyR4uCI78g77kK+PGi2NM65Mk+wKt975
+m3Qh4/cNv1ews4h+RflayWC9kiiRVzDHJGTy63k5gdplqrW2rb8gK3ZQaT2gQp9u
+gjKIIFGyi+EIDSukHNdRAoIBAQDuGvE9k1lSvoPgSusogMk7PWTiZbn8MwlEFueM
+ZJk9k8dMSkqF1k5BXG9lHcWuFl2invgTiFJIF7ML0GDsFJR+CzCDsanSGdjyKfGM
+HzHAc7UPAJYBXPX1rxTAhGSirKjArcqYUX3ZGGaTo1yZrsbbarInUhWWNKFBdaQ+
++L3oClGt3GZx7hdxapI/3gnkLvG/C5hWWetLONZAxY6jwJJSA/p2Fx93SlWOtrmT
+KRbM/p8m6sHtsXcBnYTueqWYpJ2mnBIB+Svf5acqQ2Xf8kAIw4Vw9u7a15OlIDGF
+ouWhtSkL4s0YfZjlXswOPZDlF3eT2ilf+OIjv5kEcLdDKOojAoIBAQDNUhfys2TH
+b1NFsIH6X1jtWHUEGOYIM/y/75Vw2pGLb40cMxVPtzsNCvz8id/sCuvx6yUWlBlN
+wjpa+7dOA+FgoXwv1iVsQm1zQlrt2VKaEy29C0tRkSwOjNC0bz1409wzYNnh5Bdx
+KJDvSz9zlefAryJGTSgGOothOjnguzoEJ6DxfkxNyWbxceBgN8JljDhc9dcybKdD
+Uxy2GflXhZvZfCtTbYfWoIV+dTYyZt2QE4PEPXrJHGUFE9ncGynbzAn1Cc/zGBeT
+zFNoYOCWNr7ueRNHQYMRZ1N3dYRdZ9th5mdqqa1eY5lP4PyQYZV6lwmyEfitXwNz
+vhS0sO+pNAyXAoIBAB9OiZOoESGRDTPrhdnwfQT+AIrIB1lCuKAsRsut2nw/NwAv
+8HaChA2SAs+Px5MpO6yLLGEdFnyGKTOPdX71AcVE4V8feA24+k50916OJ3N/gzny
+wMZzG5/vIlJh1f2RqCqVb0LxzBNEYxBcdWt7kIf/EmebIl16lA1QU4U4HXgqCy1K
+AmpOfOSbt5kQL8rB5WVSN/h6oDZmxb0EfMnJIzQHc+IdDjUYIAHAwsu3pljTzcdH
+LLJ9GAGtXXIhzC4yzsu+T5vU0FEDGCS1ceqtJoBAfQYqYaOCntYiUoCYt4q4kCoQ
+6xiiQv09pqTksW191WoqUDBfQBSlN5Be5am98nMCggEAIzEb+7R15J0XN82uKZzo
+IB5WSDKAUw2eF8PX6HT+F1kyZY/36ibszyp//EUhhVLF6Dw2qi0OPT66Q9f7LjsK
+CUcEgyqAVZL5MZVBAp2KQ/BfmZRy/3MTixbluteKQMiHaKMEFWzD+9hJJ0rNgGFE
+TMl35XbaEl88fpi9TOCqbAXi1yGfsIGBzIaJP9Su1Dr5ei2FChaHgMmhFTFUhITZ
+FqjqwCz46HexCeDLPk5VUZmWry8eeZQNWJZzc/+P6CWL210oMHGDsQiHj09zjyup
+BDTqcf8vmO8N5l7VJjFj797PAQA+P/xwTbmxcInZVh7HQadE6WpsrAz7fZEKMwVB
+1wKCAQEA3oqXI9bGGoXFjydUiNMZbuHdIDQCa9t7iDb+J+NAiA7GI8W8DlFYrUST
+S/CoBey/WOW9jPT/A8EBnp8RmPtAJH88qklbqh/YCoKyKZrgqT5IGysRLWwDFrGT
+QoOvR1a6SaVMLskmYUCkl8Yz8sZS58X50ahxx5TB0I3xsoCmnMZt+cd2C/VXwhFz
+jCiEZIuQlSgQFW4LOFrxrXmI+MDOBWu4zvkztWOnTe+BNgrxndGVI6sdFGzWeNQx
+dQ9imn0UqGSkgnJEj7Lq67ey8Cuu6yYWexKI0N9UOcyL4FgaEdWiJ0t5KY6NElGI
+0jrZX7pwVf/pvbKW2zVm6nXjWJ/JFw==
+-----END PRIVATE KEY-----
+</key>
+<dh>
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEAqJI9Luwkfy0E95gqZyq031Fa1rUCW5aBoppgm4YHxGUL+fUQzveF
+U2+W5xzmZuxhyoN0PVqlPXoMi0xGyTW4ga8qMaIHDqQ/V8RNxQYJ+GEEiC46/2u9
+Co/HbGX9YXMm5nnNEtHepAHcJiRB6QbCjzVm06x5QfWifj/yTm9ycVfJXhQJiOkD
+j4y4vJbgrmIKWX8Nxj4Q8dCAJzZ2gFvMnW9XcbS9SYbyvS0DvoQG3gPTGcopv7x1
+NiOhrxcTcMjwi/2z6kxG0MJEZ1HOJ2xTtRReUGXkL0lhbVTzkX4V6ihWK4MZYqe+
+ozy/0gbPAB4dT1QNeSRXPOi9f81Oed0SoC83P0oiq3JRQq2g7aS9OiwqlRPnVnvH
+q7Uko6+nv8XLbANgbdLXc8I3K78TSedwofxI/atxKncEic0fHV5ai2IdEWt22qxj
+iWVyaiHlWtMosZvuepSPn3cAmfuj0dVPNiRoG97neN8XIOaVZNGmNnI4yM0JEA1h
+Ef4Lh4YpDdqk4Q/nC/zJev8PM1XC+Os1SsGH50YAn8q19TGzI26/Y4jWfqrHswsj
+6vF/lxDS5RRzLIqlEksm84MU1q0AFSe9FaW1NTtKR/PLO1QiSKr718BwzzrDNN9u
+KZJabQ9n1RgLSuMP9zk9A6GUPQ7cZ0fJchUPeuF8Cd7zAV7k4m0RA4MCAQI=
+-----END DH PARAMETERS-----
+</dh>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.4.6-alpine-3.8/Dockerfile
+++ b/variants/2.4.6-alpine-3.8/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.8
+
+RUN apk add --no-cache openvpn~=2.4.6 iptables
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/2.4.6-alpine-3.8/docker-compose.yml
+++ b/variants/2.4.6-alpine-3.8/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '2.1'
+services:
+  openvpn-server:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
+      - NAT_MASQUERADE=1
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/server.conf:/etc/openvpn/server.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    ports:
+      - 1194:1194/udp
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped

--- a/variants/2.4.6-alpine-3.8/docker-entrypoint.sh
+++ b/variants/2.4.6-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+# Env vars
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
+OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
+NAT=${NAT:-1}
+NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
+CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    echo "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
+
+# If no args are passed, run the entrypoint. If a flag is passed, run openvpn directly. Else, run the passed command
+if [ "$#" -eq 0 ]; then
+    # Provision
+    echo "Provisioning tun device"
+    mkdir -p /dev/net
+    if [ ! -c /dev/net/tun ]; then
+        mknod /dev/net/tun c 10 200
+    fi
+    if [ -f "$CUSTOM_FIREWALL_SCRIPT" ]; then
+        echo "Executing custom firewall script: $CUSTOM_FIREWALL_SCRIPT"
+        . "$CUSTOM_FIREWALL_SCRIPT"
+    else
+        echo "Not executing custom firewall script $CUSTOM_FIREWALL_SCRIPT because it does not exist"
+    fi
+    if [ "$NAT" = 1 ]; then
+        echo "NAT is enabled"
+        echo "Provisioning NAT iptables rules"
+        echo "NAT_INTERFACE: $NAT_INTERFACE"
+        if [ "$NAT_MASQUERADE" = 1 ]; then
+            echo "NAT_MASQUERADE is enabled"
+            iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+            if [ -n "$OPENVPN_ROUTES" ]; then
+                echo "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+                for r in $OPENVPN_ROUTES; do
+                    iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+                done
+            else
+                echo "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+            fi
+        else
+            echo "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
+        fi
+    else
+        echo "NAT is disabled."
+        echo "Not adding NAT iptables rules"
+    fi
+
+    echo "Listing iptables rules:"
+    iptables -L -nv
+    echo "Listing iptables NAT rules:"
+    iptables -L -nv -t nat
+
+    # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
+    set openvpn --cd /etc/openvpn --config "$OPENVPN_CONFIG_FILE"
+    echo "openvpn command line: $@"
+    exec "$@"
+elif [ "$#" -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    echo "openvpn command line: $@"
+    exec openvpn "$@"
+fi
+
+exec "$@"

--- a/variants/2.4.6-alpine-3.8/openvpn/client.conf
+++ b/variants/2.4.6-alpine-3.8/openvpn/client.conf
@@ -1,0 +1,258 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/client.conf
+client
+dev tun
+proto udp
+remote openvpn-server 1194
+remote-random
+# Push all traffic into the tunnel
+;redirect-gateway def1 bypass-dhcp
+resolv-retry infinite
+nobind
+user nobody
+group nobody
+persist-key
+persist-tun
+remote-cert-tls server
+cipher AES-256-CBC
+auth SHA512
+comp-lzo
+verb 4
+key-direction 1
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:4e:3e:ee:0c:a0:be:17:77:36:7e:3e:48:bf:5a:f3
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=client-01
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:b3:ef:25:0f:86:77:8e:9f:a4:42:02:f0:19:0e:
+                    20:0e:93:5e:67:78:17:99:a9:cd:06:84:fe:c1:ed:
+                    5b:c9:96:d1:82:ef:5f:a5:95:d7:de:99:97:84:cc:
+                    a8:28:13:69:2f:41:7a:d4:f0:ac:a7:a3:10:8a:31:
+                    c6:aa:14:dd:d0:5d:15:51:2c:e9:5e:3e:fe:f0:1c:
+                    d7:62:07:f7:fb:01:93:22:8f:4b:72:77:76:8a:14:
+                    fe:26:52:59:c8:59:b0:01:b6:cb:7a:2d:ba:0d:35:
+                    a2:8c:42:97:18:54:45:58:f1:69:ff:3b:ce:fd:71:
+                    a5:13:42:82:ca:e2:25:43:61:d6:34:1f:f6:f3:36:
+                    7f:c9:7d:a4:e2:83:f1:8f:b7:2d:cd:7f:cf:1a:90:
+                    a4:86:ce:c0:6b:36:b3:9e:90:d0:60:5c:ec:ac:70:
+                    f7:32:16:59:20:1f:27:a5:3c:00:a0:9b:63:30:41:
+                    a5:d3:63:37:9d:10:f7:f6:53:45:54:57:70:7e:06:
+                    a6:01:32:38:2c:2d:d1:11:4c:3f:57:25:5a:2c:2c:
+                    06:a0:20:bb:c0:95:fd:44:a8:0d:3a:b0:c9:a3:b2:
+                    77:ce:f7:f0:f5:c8:1c:a7:74:ba:b9:83:0b:3c:56:
+                    6f:18:cb:df:39:77:3a:69:18:57:be:48:7e:ab:2a:
+                    21:2d:b0:eb:4c:26:ae:93:f2:d9:0d:29:01:b8:2c:
+                    0b:5a:ec:8a:c0:fd:5d:1c:a7:6f:31:29:5d:5c:35:
+                    cd:0e:e0:97:86:07:af:5e:69:8e:e7:e1:f0:78:21:
+                    f3:15:c6:35:cd:e6:4b:65:d5:17:0b:87:6e:ea:39:
+                    44:96:ab:bc:fc:ee:27:85:fe:10:c4:77:96:25:cd:
+                    9a:66:ee:e4:36:fb:f0:c8:90:62:de:6d:f6:8c:19:
+                    76:c6:6d:c3:9c:a4:9f:80:ec:39:79:ba:32:36:b2:
+                    7d:93:3c:dc:58:c5:13:34:35:8a:7e:cb:cc:f0:9a:
+                    bb:39:dd:ca:bc:cf:c7:7a:8f:9b:60:f1:a8:e6:e4:
+                    41:62:82:cd:cc:d2:81:06:c1:5b:82:0c:49:88:e6:
+                    bd:39:b2:06:82:a0:fb:55:ba:fd:de:57:2f:40:84:
+                    07:b8:38:9a:49:6e:38:49:c0:b9:26:f7:7e:a9:9a:
+                    18:b3:27:b9:d9:b3:fb:7f:6d:9e:68:58:94:f7:b1:
+                    21:b5:ee:59:b0:7f:fc:0f:ab:00:c2:8e:94:34:09:
+                    c3:45:dd:4c:79:03:b8:bf:ce:55:8f:6e:6d:c9:ff:
+                    4c:5b:da:fb:eb:70:bd:c9:37:68:6e:03:e0:db:2f:
+                    6e:db:6c:d4:f0:1f:01:43:42:6e:f6:31:4b:8d:fb:
+                    21:1e:77
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                23:46:34:1C:74:3B:D8:21:40:4D:81:B3:58:9F:57:CB:0C:5E:90:FB
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+    Signature Algorithm: sha256WithRSAEncryption
+         3c:80:ef:a8:a1:94:bc:12:33:6c:19:2e:44:44:6c:20:8e:69:
+         f6:b8:21:ad:4b:f7:14:d6:bf:c3:8d:b0:87:d1:e2:55:df:c0:
+         fd:03:31:82:8a:82:dd:68:3d:61:1f:c4:89:eb:e6:07:b0:89:
+         1d:19:8b:ee:57:9f:87:d8:a2:d8:fe:84:ad:f1:18:9c:b5:93:
+         a1:17:48:41:1e:f7:12:1e:50:46:b7:57:93:6e:d5:0f:d5:84:
+         a8:8e:74:4f:ab:8a:ae:40:64:8a:a8:57:32:75:b6:82:20:10:
+         be:ab:70:0c:96:c7:30:f4:69:c7:c9:24:db:3a:bc:40:eb:ac:
+         ee:04:f3:58:4a:09:6e:42:01:b4:a5:77:e5:2b:01:05:c1:5c:
+         08:59:0b:e3:a9:7a:b4:3e:f9:41:8d:2b:e6:8e:40:27:07:07:
+         0d:b0:03:ba:c9:d2:cd:dd:3c:9a:7e:20:66:bb:7f:4f:9d:fc:
+         37:16:88:84:a1:26:6a:91:43:d1:47:82:cb:e1:84:d4:03:93:
+         ec:8d:14:ce:2c:c8:fc:96:f8:28:d5:cb:89:c8:84:ee:8a:54:
+         8e:3c:12:86:10:73:78:5c:b8:a5:7d:99:94:b1:e1:f9:18:ed:
+         4b:2f:ae:8d:d4:9b:bc:20:21:d3:13:ed:07:15:70:dc:d1:1f:
+         58:22:fc:0e:5a:49:4e:6f:c1:99:9d:de:71:4e:62:7d:ad:d3:
+         2e:c3:ca:3f:db:cf:f3:46:aa:95:1f:99:1c:81:f8:15:5a:a1:
+         30:f7:7b:4a:e1:8a:fa:8b:a4:92:6d:11:e3:4c:f5:2b:b9:a3:
+         6d:a4:07:93:cb:28:f7:06:c1:e8:1b:1e:c5:aa:76:51:7e:1b:
+         a7:fe:db:9b:d4:23:d1:2a:16:52:ed:d1:2c:55:2b:cd:db:73:
+         fa:20:1a:18:47:af:90:50:0c:fe:1b:0d:f6:06:ec:33:1f:8e:
+         6f:f2:9a:d0:49:88:cb:a0:8c:8a:60:54:8e:d0:c1:59:ad:e6:
+         6e:6a:3e:e4:3b:b4:1b:01:8e:81:a4:f2:21:94:d1:a7:5e:e8:
+         1a:14:af:f1:46:5d:6a:ad:9d:06:02:84:58:96:b2:e6:f8:02:
+         5f:ce:ed:87:54:b5:f9:b6:62:97:51:b2:88:05:49:de:fd:56:
+         d1:67:e5:59:78:31:82:36:17:ce:07:62:81:5c:19:82:48:22:
+         88:15:ea:d9:fc:1e:c3:ee:05:a5:ec:e9:ca:69:b5:2a:7e:79:
+         ed:aa:6e:3f:b5:45:75:0b:d4:27:e4:4c:88:04:e0:06:36:5e:
+         41:37:b0:f5:44:80:58:86:dc:c1:be:82:62:fe:a8:2c:6c:ca:
+         6a:f8:dd:fd:85:df:5a:41
+-----BEGIN CERTIFICATE-----
+MIIFUTCCAzmgAwIBAgIQDU4+7gygvhd3Nn4+SL9a8zANBgkqhkiG9w0BAQsFADAT
+MREwDwYDVQQDDAhDaGFuZ2VNZTAeFw0yMzA2MzAxMTQ1MTJaFw0yNTEwMDIxMTQ1
+MTJaMBQxEjAQBgNVBAMMCWNsaWVudC0wMTCCAiIwDQYJKoZIhvcNAQEBBQADggIP
+ADCCAgoCggIBALPvJQ+Gd46fpEIC8BkOIA6TXmd4F5mpzQaE/sHtW8mW0YLvX6WV
+196Zl4TMqCgTaS9BetTwrKejEIoxxqoU3dBdFVEs6V4+/vAc12IH9/sBkyKPS3J3
+dooU/iZSWchZsAG2y3otug01ooxClxhURVjxaf87zv1xpRNCgsriJUNh1jQf9vM2
+f8l9pOKD8Y+3Lc1/zxqQpIbOwGs2s56Q0GBc7Kxw9zIWWSAfJ6U8AKCbYzBBpdNj
+N50Q9/ZTRVRXcH4GpgEyOCwt0RFMP1clWiwsBqAgu8CV/USoDTqwyaOyd8738PXI
+HKd0urmDCzxWbxjL3zl3OmkYV75IfqsqIS2w60wmrpPy2Q0pAbgsC1rsisD9XRyn
+bzEpXVw1zQ7gl4YHr15pjufh8Hgh8xXGNc3mS2XVFwuHbuo5RJarvPzuJ4X+EMR3
+liXNmmbu5Db78MiQYt5t9owZdsZtw5ykn4DsOXm6MjayfZM83FjFEzQ1in7LzPCa
+uzndyrzPx3qPm2DxqObkQWKCzczSgQbBW4IMSYjmvTmyBoKg+1W6/d5XL0CEB7g4
+mkluOEnAuSb3fqmaGLMnudmz+39tnmhYlPexIbXuWbB//A+rAMKOlDQJw0XdTHkD
+uL/OVY9ubcn/TFva++twvck3aG4D4Nsvbtts1PAfAUNCbvYxS437IR53AgMBAAGj
+gZ8wgZwwCQYDVR0TBAIwADAdBgNVHQ4EFgQUI0Y0HHQ72CFATYGzWJ9XywxekPsw
+TgYDVR0jBEcwRYAUmBuw7bvaYZi1OnrIxE4ycKX4qQehF6QVMBMxETAPBgNVBAMM
+CENoYW5nZU1lghQRFLv/ZzUIweAY3+3bxHLwDm1FLDATBgNVHSUEDDAKBggrBgEF
+BQcDAjALBgNVHQ8EBAMCB4AwDQYJKoZIhvcNAQELBQADggIBADyA76ihlLwSM2wZ
+LkREbCCOafa4Ia1L9xTWv8ONsIfR4lXfwP0DMYKKgt1oPWEfxInr5gewiR0Zi+5X
+n4fYotj+hK3xGJy1k6EXSEEe9xIeUEa3V5Nu1Q/VhKiOdE+riq5AZIqoVzJ1toIg
+EL6rcAyWxzD0acfJJNs6vEDrrO4E81hKCW5CAbSld+UrAQXBXAhZC+OperQ++UGN
+K+aOQCcHBw2wA7rJ0s3dPJp+IGa7f0+d/DcWiIShJmqRQ9FHgsvhhNQDk+yNFM4s
+yPyW+CjVy4nIhO6KVI48EoYQc3hcuKV9mZSx4fkY7Usvro3Um7wgIdMT7QcVcNzR
+H1gi/A5aSU5vwZmd3nFOYn2t0y7Dyj/bz/NGqpUfmRyB+BVaoTD3e0rhivqLpJJt
+EeNM9Su5o22kB5PLKPcGwegbHsWqdlF+G6f+25vUI9EqFlLt0SxVK83bc/ogGhhH
+r5BQDP4bDfYG7DMfjm/ymtBJiMugjIpgVI7QwVmt5m5qPuQ7tBsBjoGk8iGU0ade
+6BoUr/FGXWqtnQYChFiWsub4Al/O7YdUtfm2YpdRsogFSd79VtFn5Vl4MYI2F84H
+YoFcGYJIIogV6tn8HsPuBaXs6cpptSp+ee2qbj+1RXUL1CfkTIgE4AY2XkE3sPVE
+gFiG3MG+gmL+qCxsymr43f2F31pB
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQCz7yUPhneOn6RC
+AvAZDiAOk15neBeZqc0GhP7B7VvJltGC71+lldfemZeEzKgoE2kvQXrU8KynoxCK
+McaqFN3QXRVRLOlePv7wHNdiB/f7AZMij0tyd3aKFP4mUlnIWbABtst6LboNNaKM
+QpcYVEVY8Wn/O879caUTQoLK4iVDYdY0H/bzNn/JfaTig/GPty3Nf88akKSGzsBr
+NrOekNBgXOyscPcyFlkgHyelPACgm2MwQaXTYzedEPf2U0VUV3B+BqYBMjgsLdER
+TD9XJVosLAagILvAlf1EqA06sMmjsnfO9/D1yByndLq5gws8Vm8Yy985dzppGFe+
+SH6rKiEtsOtMJq6T8tkNKQG4LAta7IrA/V0cp28xKV1cNc0O4JeGB69eaY7n4fB4
+IfMVxjXN5ktl1RcLh27qOUSWq7z87ieF/hDEd5YlzZpm7uQ2+/DIkGLebfaMGXbG
+bcOcpJ+A7Dl5ujI2sn2TPNxYxRM0NYp+y8zwmrs53cq8z8d6j5tg8ajm5EFigs3M
+0oEGwVuCDEmI5r05sgaCoPtVuv3eVy9AhAe4OJpJbjhJwLkm936pmhizJ7nZs/t/
+bZ5oWJT3sSG17lmwf/wPqwDCjpQ0CcNF3Ux5A7i/zlWPbm3J/0xb2vvrcL3JN2hu
+A+DbL27bbNTwHwFDQm72MUuN+yEedwIDAQABAoICAAuYKlwwvv16vfve8pe6uEgY
+KOoj6+lj7qkv4raeU97OkBuOzyv9VtaqMQBGq8NBVPLNlluoUofO0x8EjBejlpN5
+nAkKCtOe3ZCdWyee+dS7yj5c23C5z/Kf3ayce9qUJOpHXB84WRfGz/2XwOK5c2qC
+y+C9et4L96YhEAqAvgP0hvf+40vSxDM4nGpYNDWdiR8H0FGW5nMlWXLPKI3cKQE8
+m6eU8+jPVdjjCQv1rNisipyubkAL0aaWVFQUE5CWvdHxHbtQABygqyshLaew6XmV
+MKwaz95eC97jsU6J28RnmJ7GjUlZJreHpwyTLCMsMqZ3ZJ/wVdw1zFmflEH1SgPq
+/JNd0OONKm8x7nORX9dHEn33Imfyg2jI6tzVx1oAmMWMb9hJ0XjkIyzjfHTPi5KW
+pM3pTUUn6ee4P1T4ReBlatiw2TFgAd18/9gSIaSlENEjslJGQ6/Ndt9O7UNHgwth
+ZNtPovjNLqUobHGXlmwg3haeBshn9iPcjdksAjgtjEyowzq7IpiSxQezXNcMezGM
+Y9UL5Qc/yjQ3t+Vu94Jmnu0TT3lHGWa3zSgI6L+UdBiIsLF6P5YQVloYOYWE3q/n
+HTaORoZlsRKfMIUHmhrZ1keJ4VGqLruSpQHobh3Cfb/xzgOEB3nSwhIK3l2FhSiR
+N9jb0r7kMElO+xlm7NChAoIBAQDllnlfyWnTBGog8+T9eJiODuBfdozy2vCZO8nc
+vp11NC7fLh5NXR16Ju6I+dcXDhPdoOG8H/DScjer82kEINrY7Wb4swNd01cLCg+/
+xVNe9iiLl4Q4m/QOI6ZOUbOfJjH9R8J4Bh/FzR1MXtVktgtsd6JB3zv6V246zDjy
+eMnOImwoj6TH/3hI/g2s5i3GoaC7CK+XjpdfZbVAX5+mnpZxBbOqXt7an1IzYHhx
+hQO8uo/9b2IDxMrWWn80mGj9Fw5AdK1Ef3eMtbyG6iOIR92UEo9ZwlZ9Tang58Sa
+7IFHZko/HcCrS92Hl9YcnYmjG0GDeFl4des+IcVz0AHDhe6RAoIBAQDIolXgCYO3
+zo2MtoBTCr+GcluT4DD16ALz7wd8/jXFqmD3UWCAeaS5IsTno1PmuIpvB7dvwz8B
+6SOpE//J/bECDmhE18UHYOAqkXzzuuEGMCP1TuaCWBq7kWV8GVTRcSGQDxLyf/Yu
+IdxiPQMaCxi0Ffv+aq27Nii1IyV8tyDL3skyGZeQJNW2xjNkngkXsB5Tp7H7tA0G
+lSmld1Rtq2XWcRnHQh9ZVP+FxwkjBkdoX0oAASVQwHsy9Q4hZ5ykxPkIGULj3Hw5
+zvG1RAM5B4GQegK0OfYuX5Ullrz6a/6p/FnGLvRkZGlHML/bHTmrr8ywSvF63Gkd
+oU0nqjPFQ1CHAoIBACoFR4PDno3TwgTz/tZxqyJdEK4ISbXtYpn5OnIfpTwdZ/LL
+QxqPz2RbGc+SQs7icbpfxtEi23X5F71uGKt7w/JuSSl9wkD6/HR1y/oiiKbZ0QPz
+oGyoBpxL5BVzmLepSv77kllbbZdLenBO7ym2tBKPNvBthlHEjNVQKaAfgXgsDrXB
+zLwaQw7BCQm7O2eej4eMCG9p1sTMHceBePwLDKf1DjRBlvJWtLnYj1LfsJZrYw1U
+xJDCBQoEmEGtH5IrFR2w/UGLPvtPDAl5czVvSdvfJcOc8S2P+GbEpNRiMys5Sp+Q
+t4HiqdI2dSbZoqZqx6vjbCTDGGJP1g7jZF8/9TECggEAXOXVj2O4an4oSnQiXNEI
+N29x+bl/0gy4eUw/El/+c+Tc+wbiAPrSC6sOsxaL/bOK3bgb9pLX9MGHcn1BHbzq
+ncIgA2hI4Y64nN06lvv7v0rBC4+Z6dZzok/DRr/P5x5T5Qklw8T+LwQcsBwB+KgU
+qyXWxUmN4bZFCQIaFHISrHMeg6UX6XU0w2loWHlYSnCQyjlGjv4iXd7pJqVnIVSQ
+VceOoRV7wHg7zCyJjX8Vxzz/3ZqqNYa6RLD09wCrphtSF67iqvDnUDkC7+Rq/Zf9
+JPFpmRuRYo19WKdAH0+r3fdrdfk9zdI0cPMgkosordc7lpFM2I9/2GlceTY0vGzb
+twKCAQEArUbkiwUZFjdjAbKS2m0uPJyytB8bZ335szcoMUV665hzU9EJPcWeVY0L
+1FSRu/cig+ZCmpUEc/4JhJVKLEEXgC3BgfHGNHi5PIuvssMT/fJJ9InQe8n4Zq0Q
+eZbrfAewrdH3bTpEf6AxIsrMioLsUQSV12iRQ7olsEP9t5HqRKqwhAnqp+q33XT3
+L++8IcaaEQ3S/sBb23pY+VSWQfKGFVQES+P7yKeNHjBNQpJTPOdM9iLtvriUmNdO
+Gy5HOpLgd10DzXBOI7CgqzFm69Bqk+WFZXGVd9T/Ku69B8XfshoRChGbgHbbEG70
+0xT4AQEuygYVBbUrIerZFpDD+Tw7ww==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.4.6-alpine-3.8/openvpn/firewall.sh
+++ b/variants/2.4.6-alpine-3.8/openvpn/firewall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# This iptables script to controlling traffic in the openvpn tunnel.
+# In this example, clients can only perform DNS, HTTP and HTTPS requests to the world.
+
+# Drop everything by default from tunnel to world
+iptables -P FORWARD DROP
+# Allow DNS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p udp -m udp --dport 53 -m conntrack --ctstate NEW -j ACCEPT
+# Allow HTTP and HTTPS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p tcp -m tcp -m conntrack --ctstate NEW -m multiport --dports 80,443 -j ACCEPT

--- a/variants/2.4.6-alpine-3.8/openvpn/server.conf
+++ b/variants/2.4.6-alpine-3.8/openvpn/server.conf
@@ -1,0 +1,280 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/server.conf
+port 1194
+proto udp
+dev tun
+server 10.8.0.0 255.255.255.0
+ifconfig-pool-persist tun-ipp.txt
+;client-config-dir ccd
+keepalive 10 120
+comp-lzo no
+max-clients 5
+user nobody
+group nogroup
+persist-key
+persist-tun
+status tun.status
+status-version 3
+;log-append server.log
+verb 4
+mute 20
+;duplicate-cn
+tls-version-min 1.2
+cipher AES-256-CBC
+auth SHA512
+key-direction 0
+;crl-verify crl.pem
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            97:80:c6:6b:b5:84:81:b3:2b:f6:56:55:da:67:4d:c8
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=server
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:be:f7:ee:15:bc:b6:e1:04:28:3e:38:6a:61:dd:
+                    ee:fa:61:85:9a:a7:be:44:22:52:b4:cf:7a:86:0e:
+                    21:ae:1e:2b:61:66:17:1f:54:dc:e9:75:27:55:24:
+                    39:fc:ee:92:d1:da:de:e2:5f:01:50:b6:ae:52:1a:
+                    79:6b:8d:56:0d:83:f6:d4:19:50:48:bc:cb:d8:69:
+                    c8:79:d4:ba:82:05:db:aa:58:12:4b:34:1b:15:d1:
+                    28:2d:b7:08:4e:a0:64:fb:c6:b4:e2:8b:61:68:4e:
+                    72:72:cc:da:a2:d8:cb:f5:6a:5d:13:b6:98:d3:0c:
+                    a3:05:7a:21:e3:f9:fb:de:89:be:37:ac:ce:4c:2e:
+                    95:98:9e:48:3c:04:97:cd:a3:36:92:15:12:a4:bf:
+                    46:ea:95:37:0c:6f:09:e1:51:f5:4e:13:9f:f5:68:
+                    65:0e:24:38:62:04:f8:f9:0c:06:72:c9:03:ed:5d:
+                    6f:40:3b:62:ea:a2:79:01:79:d0:58:aa:2c:7f:89:
+                    14:bc:3e:86:c0:5e:58:ac:58:c0:97:fe:65:57:46:
+                    bf:01:cc:d4:d7:64:d8:21:15:02:6b:6a:38:24:bb:
+                    2b:45:c7:79:23:7a:7f:0c:6b:25:d3:ce:e1:3f:e8:
+                    68:6c:31:7a:df:88:49:6d:a3:7e:22:24:08:3d:e1:
+                    6c:87:dd:34:77:d2:a5:eb:f7:e6:74:b9:e2:5f:e4:
+                    ad:49:e1:c0:b4:8f:d9:b5:ac:2d:7b:ba:22:64:8e:
+                    b7:c1:11:11:f1:e1:1f:b9:3e:29:b1:61:9b:8a:1c:
+                    2e:d4:e4:e6:10:5a:5d:e1:f9:1e:54:7b:13:79:dd:
+                    d9:ad:8b:23:c4:8d:a5:8b:f5:17:eb:99:96:5d:c6:
+                    8d:b4:af:8b:4c:2f:08:4d:37:c3:bf:6d:68:99:c4:
+                    f7:47:cc:5d:44:e7:6e:f2:64:b3:7d:bb:9b:c7:e1:
+                    27:cf:73:8d:b2:e2:88:19:6c:bb:6e:cd:4a:0a:79:
+                    a8:7b:9d:c3:b0:59:93:51:20:a1:d8:a2:0f:e5:62:
+                    76:17:b3:bb:aa:bc:3a:73:e7:f6:57:91:6a:cb:d3:
+                    7e:91:38:5e:88:57:e3:d8:3e:31:cd:dc:69:9a:74:
+                    bb:6e:62:c2:ab:5b:8c:f5:80:ff:b4:98:a2:87:15:
+                    72:38:77:76:dc:e2:d1:ac:2f:66:67:ae:c4:33:a8:
+                    86:94:af:41:b1:99:0d:5d:68:df:9a:ec:86:0f:0a:
+                    c9:67:fa:a1:7c:29:47:d3:f1:c1:3d:8a:d1:a4:12:
+                    a6:70:16:37:80:4f:d9:79:61:45:1c:07:77:68:60:
+                    4e:10:ec:94:dd:03:95:b1:37:cc:88:3d:60:cc:32:
+                    37:be:a5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                4A:91:C2:3E:A1:E9:04:C9:C0:9A:8B:CE:D4:37:4D:96:0E:74:FE:90
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication
+            X509v3 Key Usage:
+                Digital Signature, Key Encipherment
+            X509v3 Subject Alternative Name:
+                DNS:server
+    Signature Algorithm: sha256WithRSAEncryption
+         72:b4:75:02:f7:7b:e9:07:c6:79:1b:bb:11:e4:73:4a:b4:76:
+         1c:03:b9:58:8c:0a:80:f0:c6:8c:cc:2a:a7:c7:8c:57:a8:6e:
+         52:19:f0:b5:7c:0f:06:ab:2f:04:0e:99:32:b9:2c:b6:42:f0:
+         f5:5b:97:32:ce:bb:0c:ee:9f:b0:0b:bc:0b:c0:43:1d:7d:04:
+         b4:a1:cf:a0:aa:fe:f1:cc:b4:31:b3:bb:78:ed:0e:60:8d:37:
+         ea:48:a7:b4:2d:6d:64:6e:97:15:aa:e4:9b:b4:68:79:c8:3b:
+         ba:91:0b:db:cd:04:a3:aa:e4:69:59:06:ec:50:68:6d:0d:a6:
+         38:32:55:76:09:10:00:da:ac:a8:9e:ad:ad:95:8f:01:88:c9:
+         40:af:9a:5c:2d:17:34:81:6b:26:65:8a:e5:2a:15:79:13:2d:
+         ae:d8:03:16:6b:e9:b6:cd:f3:cb:d5:4d:5f:40:76:7a:99:99:
+         d5:2f:e8:a1:59:88:01:6b:a1:36:c0:53:dc:46:07:fd:ab:ab:
+         2a:5b:d3:d5:4c:84:c2:fb:48:16:80:80:01:f6:37:80:3a:54:
+         81:11:24:86:a6:a2:9a:73:06:5f:ca:24:8c:20:3a:40:6e:95:
+         8e:44:46:ef:60:bc:9d:11:ad:71:af:61:85:a6:e2:b4:49:c7:
+         fa:bb:ef:b5:c9:02:d2:a2:a5:3b:f6:46:03:dc:58:9f:ff:dc:
+         23:6b:b5:02:4c:1a:1a:80:99:6d:1a:fd:24:fc:32:83:f7:de:
+         fd:2b:b2:45:b7:3b:89:3c:49:0c:3d:0b:05:67:a5:95:00:3d:
+         cd:a7:0a:3b:b5:cd:02:10:09:de:ff:6c:6b:8b:aa:9d:e6:e9:
+         07:83:e2:dd:de:6d:bc:9e:fd:19:77:30:5d:67:12:c2:33:40:
+         0f:13:69:98:02:ef:05:b2:ad:ef:fb:73:15:57:70:46:83:32:
+         a9:05:4d:31:06:3d:44:93:88:69:de:9a:67:b4:6b:b7:0d:6b:
+         69:24:8b:62:52:f7:85:66:8f:84:2d:c0:a7:ff:33:37:7c:f3:
+         d1:1f:8c:b6:16:a3:98:db:6e:aa:e5:eb:d8:ed:06:31:19:ba:
+         01:f1:e6:3e:bc:78:ec:6e:b4:af:6c:8a:49:0f:ff:5a:f0:00:
+         88:d8:66:af:d6:49:31:b5:54:ce:be:07:59:46:bb:67:73:4b:
+         b8:ec:be:16:04:ed:fe:75:57:21:d6:d5:7b:cc:d0:7c:bd:91:
+         d3:6e:61:72:04:30:24:45:0a:0d:16:b6:35:94:49:02:14:8d:
+         2d:1d:71:42:13:9a:02:1e:3c:31:05:b4:76:5b:dd:ff:bb:db:
+         f4:31:b7:47:bb:54:f8:27
+-----BEGIN CERTIFICATE-----
+MIIFYjCCA0qgAwIBAgIRAJeAxmu1hIGzK/ZWVdpnTcgwDQYJKoZIhvcNAQELBQAw
+EzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMjUxMDAyMTE0
+NTEyWjARMQ8wDQYDVQQDDAZzZXJ2ZXIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+ggIKAoICAQC+9+4VvLbhBCg+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzp
+dSdVJDn87pLR2t7iXwFQtq5SGnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV
+0SgttwhOoGT7xrTii2FoTnJyzNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWY
+nkg8BJfNozaSFRKkv0bqlTcMbwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2Lq
+onkBedBYqix/iRS8PobAXlisWMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8M
+ayXTzuE/6GhsMXrfiElto34iJAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17
+uiJkjrfBERHx4R+5PimxYZuKHC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZd
+xo20r4tMLwhNN8O/bWiZxPdHzF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7
+ncOwWZNRIKHYog/lYnYXs7uqvDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKr
+W4z1gP+0mKKHFXI4d3bc4tGsL2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT
+8cE9itGkEqZwFjeAT9l5YUUcB3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABo4Gy
+MIGvMAkGA1UdEwQCMAAwHQYDVR0OBBYEFEqRwj6h6QTJwJqLztQ3TZYOdP6QME4G
+A1UdIwRHMEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhD
+aGFuZ2VNZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwEwYDVR0lBAwwCgYIKwYBBQUH
+AwEwCwYDVR0PBAQDAgWgMBEGA1UdEQQKMAiCBnNlcnZlcjANBgkqhkiG9w0BAQsF
+AAOCAgEAcrR1Avd76QfGeRu7EeRzSrR2HAO5WIwKgPDGjMwqp8eMV6huUhnwtXwP
+BqsvBA6ZMrkstkLw9VuXMs67DO6fsAu8C8BDHX0EtKHPoKr+8cy0MbO7eO0OYI03
+6kintC1tZG6XFarkm7Roecg7upEL280Eo6rkaVkG7FBobQ2mODJVdgkQANqsqJ6t
+rZWPAYjJQK+aXC0XNIFrJmWK5SoVeRMtrtgDFmvpts3zy9VNX0B2epmZ1S/ooVmI
+AWuhNsBT3EYH/aurKlvT1UyEwvtIFoCAAfY3gDpUgREkhqaimnMGX8okjCA6QG6V
+jkRG72C8nRGtca9hhabitEnH+rvvtckC0qKlO/ZGA9xYn//cI2u1AkwaGoCZbRr9
+JPwyg/fe/SuyRbc7iTxJDD0LBWellQA9zacKO7XNAhAJ3v9sa4uqnebpB4Pi3d5t
+vJ79GXcwXWcSwjNADxNpmALvBbKt7/tzFVdwRoMyqQVNMQY9RJOIad6aZ7Rrtw1r
+aSSLYlL3hWaPhC3Ap/8zN3zz0R+MthajmNtuquXr2O0GMRm6AfHmPrx47G60r2yK
+SQ//WvAAiNhmr9ZJMbVUzr4HWUa7Z3NLuOy+FgTt/nVXIdbVe8zQfL2R025hcgQw
+JEUKDRa2NZRJAhSNLR1xQhOaAh48MQW0dlvd/7vb9DG3R7tU+Cc=
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQC+9+4VvLbhBCg+
+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzpdSdVJDn87pLR2t7iXwFQtq5S
+GnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV0SgttwhOoGT7xrTii2FoTnJy
+zNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWYnkg8BJfNozaSFRKkv0bqlTcM
+bwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2LqonkBedBYqix/iRS8PobAXlis
+WMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8MayXTzuE/6GhsMXrfiElto34i
+JAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17uiJkjrfBERHx4R+5PimxYZuK
+HC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZdxo20r4tMLwhNN8O/bWiZxPdH
+zF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7ncOwWZNRIKHYog/lYnYXs7uq
+vDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKrW4z1gP+0mKKHFXI4d3bc4tGs
+L2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT8cE9itGkEqZwFjeAT9l5YUUc
+B3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABAoICAAnfT1OYWevwBxSQXg+JJZ2U
+BRAls9RZ4eSvBSqA+ITD0oJKgM+B15nKEKp6IPVOcBChO/x/5NWDXCeqbrR8rgIs
+3EnCtT/NYsxhS5fgw3ONUfnQa8Gvg+bw1R7n42oNKKtLbnZ3tiVqSMhehr78bi7V
+vNIUEnp2oMbbtXzPo5GxlT/TkyalEd698AYKRr6+vUd4B2q06Lmf1SSzaNNZJVFP
++mj5aJ/+h1up3iUh1gOBGM7gkavEZiyzEYZeAcNTqNE/CO9iXBz9w5/FRs+UuzBz
+29P//tDTyciMCX/8EcL0WhxVX5HR91dxApecjlB7d0qAlFWR+hnM5exl6HcqfC3C
++Uhi5IC+gZjD2KCcHDr9e5WqQ6cu8TeMnoyuHInIV9kUL3Bn1ArOU1dmGS78soeE
+GpqGCRc9Imh8jxs1AVyj9wGzpfuRS8OBpfR5MIlcFwSlZO/6dnJSaF2BH1jnKgBG
+Xn9MvjfHTU/EhLTteXrAJlqQr4e/uAK5QCESFNXLvC0r3qord6b9Y0zHR63SpESJ
+WVUIF9L2fIh0Z4CutPegcbEyWLaaAT4njyR4uCI78g77kK+PGi2NM65Mk+wKt975
+m3Qh4/cNv1ews4h+RflayWC9kiiRVzDHJGTy63k5gdplqrW2rb8gK3ZQaT2gQp9u
+gjKIIFGyi+EIDSukHNdRAoIBAQDuGvE9k1lSvoPgSusogMk7PWTiZbn8MwlEFueM
+ZJk9k8dMSkqF1k5BXG9lHcWuFl2invgTiFJIF7ML0GDsFJR+CzCDsanSGdjyKfGM
+HzHAc7UPAJYBXPX1rxTAhGSirKjArcqYUX3ZGGaTo1yZrsbbarInUhWWNKFBdaQ+
++L3oClGt3GZx7hdxapI/3gnkLvG/C5hWWetLONZAxY6jwJJSA/p2Fx93SlWOtrmT
+KRbM/p8m6sHtsXcBnYTueqWYpJ2mnBIB+Svf5acqQ2Xf8kAIw4Vw9u7a15OlIDGF
+ouWhtSkL4s0YfZjlXswOPZDlF3eT2ilf+OIjv5kEcLdDKOojAoIBAQDNUhfys2TH
+b1NFsIH6X1jtWHUEGOYIM/y/75Vw2pGLb40cMxVPtzsNCvz8id/sCuvx6yUWlBlN
+wjpa+7dOA+FgoXwv1iVsQm1zQlrt2VKaEy29C0tRkSwOjNC0bz1409wzYNnh5Bdx
+KJDvSz9zlefAryJGTSgGOothOjnguzoEJ6DxfkxNyWbxceBgN8JljDhc9dcybKdD
+Uxy2GflXhZvZfCtTbYfWoIV+dTYyZt2QE4PEPXrJHGUFE9ncGynbzAn1Cc/zGBeT
+zFNoYOCWNr7ueRNHQYMRZ1N3dYRdZ9th5mdqqa1eY5lP4PyQYZV6lwmyEfitXwNz
+vhS0sO+pNAyXAoIBAB9OiZOoESGRDTPrhdnwfQT+AIrIB1lCuKAsRsut2nw/NwAv
+8HaChA2SAs+Px5MpO6yLLGEdFnyGKTOPdX71AcVE4V8feA24+k50916OJ3N/gzny
+wMZzG5/vIlJh1f2RqCqVb0LxzBNEYxBcdWt7kIf/EmebIl16lA1QU4U4HXgqCy1K
+AmpOfOSbt5kQL8rB5WVSN/h6oDZmxb0EfMnJIzQHc+IdDjUYIAHAwsu3pljTzcdH
+LLJ9GAGtXXIhzC4yzsu+T5vU0FEDGCS1ceqtJoBAfQYqYaOCntYiUoCYt4q4kCoQ
+6xiiQv09pqTksW191WoqUDBfQBSlN5Be5am98nMCggEAIzEb+7R15J0XN82uKZzo
+IB5WSDKAUw2eF8PX6HT+F1kyZY/36ibszyp//EUhhVLF6Dw2qi0OPT66Q9f7LjsK
+CUcEgyqAVZL5MZVBAp2KQ/BfmZRy/3MTixbluteKQMiHaKMEFWzD+9hJJ0rNgGFE
+TMl35XbaEl88fpi9TOCqbAXi1yGfsIGBzIaJP9Su1Dr5ei2FChaHgMmhFTFUhITZ
+FqjqwCz46HexCeDLPk5VUZmWry8eeZQNWJZzc/+P6CWL210oMHGDsQiHj09zjyup
+BDTqcf8vmO8N5l7VJjFj797PAQA+P/xwTbmxcInZVh7HQadE6WpsrAz7fZEKMwVB
+1wKCAQEA3oqXI9bGGoXFjydUiNMZbuHdIDQCa9t7iDb+J+NAiA7GI8W8DlFYrUST
+S/CoBey/WOW9jPT/A8EBnp8RmPtAJH88qklbqh/YCoKyKZrgqT5IGysRLWwDFrGT
+QoOvR1a6SaVMLskmYUCkl8Yz8sZS58X50ahxx5TB0I3xsoCmnMZt+cd2C/VXwhFz
+jCiEZIuQlSgQFW4LOFrxrXmI+MDOBWu4zvkztWOnTe+BNgrxndGVI6sdFGzWeNQx
+dQ9imn0UqGSkgnJEj7Lq67ey8Cuu6yYWexKI0N9UOcyL4FgaEdWiJ0t5KY6NElGI
+0jrZX7pwVf/pvbKW2zVm6nXjWJ/JFw==
+-----END PRIVATE KEY-----
+</key>
+<dh>
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEAqJI9Luwkfy0E95gqZyq031Fa1rUCW5aBoppgm4YHxGUL+fUQzveF
+U2+W5xzmZuxhyoN0PVqlPXoMi0xGyTW4ga8qMaIHDqQ/V8RNxQYJ+GEEiC46/2u9
+Co/HbGX9YXMm5nnNEtHepAHcJiRB6QbCjzVm06x5QfWifj/yTm9ycVfJXhQJiOkD
+j4y4vJbgrmIKWX8Nxj4Q8dCAJzZ2gFvMnW9XcbS9SYbyvS0DvoQG3gPTGcopv7x1
+NiOhrxcTcMjwi/2z6kxG0MJEZ1HOJ2xTtRReUGXkL0lhbVTzkX4V6ihWK4MZYqe+
+ozy/0gbPAB4dT1QNeSRXPOi9f81Oed0SoC83P0oiq3JRQq2g7aS9OiwqlRPnVnvH
+q7Uko6+nv8XLbANgbdLXc8I3K78TSedwofxI/atxKncEic0fHV5ai2IdEWt22qxj
+iWVyaiHlWtMosZvuepSPn3cAmfuj0dVPNiRoG97neN8XIOaVZNGmNnI4yM0JEA1h
+Ef4Lh4YpDdqk4Q/nC/zJev8PM1XC+Os1SsGH50YAn8q19TGzI26/Y4jWfqrHswsj
+6vF/lxDS5RRzLIqlEksm84MU1q0AFSe9FaW1NTtKR/PLO1QiSKr718BwzzrDNN9u
+KZJabQ9n1RgLSuMP9zk9A6GUPQ7cZ0fJchUPeuF8Cd7zAV7k4m0RA4MCAQI=
+-----END DH PARAMETERS-----
+</dh>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.4.6-alpine-3.9/Dockerfile
+++ b/variants/2.4.6-alpine-3.9/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.9
+
+RUN apk add --no-cache openvpn~=2.4.6 iptables
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/2.4.6-alpine-3.9/docker-compose.yml
+++ b/variants/2.4.6-alpine-3.9/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '2.1'
+services:
+  openvpn-server:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
+      - NAT_MASQUERADE=1
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/server.conf:/etc/openvpn/server.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    ports:
+      - 1194:1194/udp
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped

--- a/variants/2.4.6-alpine-3.9/docker-entrypoint.sh
+++ b/variants/2.4.6-alpine-3.9/docker-entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+# Env vars
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
+OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
+NAT=${NAT:-1}
+NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
+CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    echo "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
+
+# If no args are passed, run the entrypoint. If a flag is passed, run openvpn directly. Else, run the passed command
+if [ "$#" -eq 0 ]; then
+    # Provision
+    echo "Provisioning tun device"
+    mkdir -p /dev/net
+    if [ ! -c /dev/net/tun ]; then
+        mknod /dev/net/tun c 10 200
+    fi
+    if [ -f "$CUSTOM_FIREWALL_SCRIPT" ]; then
+        echo "Executing custom firewall script: $CUSTOM_FIREWALL_SCRIPT"
+        . "$CUSTOM_FIREWALL_SCRIPT"
+    else
+        echo "Not executing custom firewall script $CUSTOM_FIREWALL_SCRIPT because it does not exist"
+    fi
+    if [ "$NAT" = 1 ]; then
+        echo "NAT is enabled"
+        echo "Provisioning NAT iptables rules"
+        echo "NAT_INTERFACE: $NAT_INTERFACE"
+        if [ "$NAT_MASQUERADE" = 1 ]; then
+            echo "NAT_MASQUERADE is enabled"
+            iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+            if [ -n "$OPENVPN_ROUTES" ]; then
+                echo "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+                for r in $OPENVPN_ROUTES; do
+                    iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+                done
+            else
+                echo "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+            fi
+        else
+            echo "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
+        fi
+    else
+        echo "NAT is disabled."
+        echo "Not adding NAT iptables rules"
+    fi
+
+    echo "Listing iptables rules:"
+    iptables -L -nv
+    echo "Listing iptables NAT rules:"
+    iptables -L -nv -t nat
+
+    # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
+    set openvpn --cd /etc/openvpn --config "$OPENVPN_CONFIG_FILE"
+    echo "openvpn command line: $@"
+    exec "$@"
+elif [ "$#" -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    echo "openvpn command line: $@"
+    exec openvpn "$@"
+fi
+
+exec "$@"

--- a/variants/2.4.6-alpine-3.9/openvpn/client.conf
+++ b/variants/2.4.6-alpine-3.9/openvpn/client.conf
@@ -1,0 +1,258 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/client.conf
+client
+dev tun
+proto udp
+remote openvpn-server 1194
+remote-random
+# Push all traffic into the tunnel
+;redirect-gateway def1 bypass-dhcp
+resolv-retry infinite
+nobind
+user nobody
+group nobody
+persist-key
+persist-tun
+remote-cert-tls server
+cipher AES-256-CBC
+auth SHA512
+comp-lzo
+verb 4
+key-direction 1
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:4e:3e:ee:0c:a0:be:17:77:36:7e:3e:48:bf:5a:f3
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=client-01
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:b3:ef:25:0f:86:77:8e:9f:a4:42:02:f0:19:0e:
+                    20:0e:93:5e:67:78:17:99:a9:cd:06:84:fe:c1:ed:
+                    5b:c9:96:d1:82:ef:5f:a5:95:d7:de:99:97:84:cc:
+                    a8:28:13:69:2f:41:7a:d4:f0:ac:a7:a3:10:8a:31:
+                    c6:aa:14:dd:d0:5d:15:51:2c:e9:5e:3e:fe:f0:1c:
+                    d7:62:07:f7:fb:01:93:22:8f:4b:72:77:76:8a:14:
+                    fe:26:52:59:c8:59:b0:01:b6:cb:7a:2d:ba:0d:35:
+                    a2:8c:42:97:18:54:45:58:f1:69:ff:3b:ce:fd:71:
+                    a5:13:42:82:ca:e2:25:43:61:d6:34:1f:f6:f3:36:
+                    7f:c9:7d:a4:e2:83:f1:8f:b7:2d:cd:7f:cf:1a:90:
+                    a4:86:ce:c0:6b:36:b3:9e:90:d0:60:5c:ec:ac:70:
+                    f7:32:16:59:20:1f:27:a5:3c:00:a0:9b:63:30:41:
+                    a5:d3:63:37:9d:10:f7:f6:53:45:54:57:70:7e:06:
+                    a6:01:32:38:2c:2d:d1:11:4c:3f:57:25:5a:2c:2c:
+                    06:a0:20:bb:c0:95:fd:44:a8:0d:3a:b0:c9:a3:b2:
+                    77:ce:f7:f0:f5:c8:1c:a7:74:ba:b9:83:0b:3c:56:
+                    6f:18:cb:df:39:77:3a:69:18:57:be:48:7e:ab:2a:
+                    21:2d:b0:eb:4c:26:ae:93:f2:d9:0d:29:01:b8:2c:
+                    0b:5a:ec:8a:c0:fd:5d:1c:a7:6f:31:29:5d:5c:35:
+                    cd:0e:e0:97:86:07:af:5e:69:8e:e7:e1:f0:78:21:
+                    f3:15:c6:35:cd:e6:4b:65:d5:17:0b:87:6e:ea:39:
+                    44:96:ab:bc:fc:ee:27:85:fe:10:c4:77:96:25:cd:
+                    9a:66:ee:e4:36:fb:f0:c8:90:62:de:6d:f6:8c:19:
+                    76:c6:6d:c3:9c:a4:9f:80:ec:39:79:ba:32:36:b2:
+                    7d:93:3c:dc:58:c5:13:34:35:8a:7e:cb:cc:f0:9a:
+                    bb:39:dd:ca:bc:cf:c7:7a:8f:9b:60:f1:a8:e6:e4:
+                    41:62:82:cd:cc:d2:81:06:c1:5b:82:0c:49:88:e6:
+                    bd:39:b2:06:82:a0:fb:55:ba:fd:de:57:2f:40:84:
+                    07:b8:38:9a:49:6e:38:49:c0:b9:26:f7:7e:a9:9a:
+                    18:b3:27:b9:d9:b3:fb:7f:6d:9e:68:58:94:f7:b1:
+                    21:b5:ee:59:b0:7f:fc:0f:ab:00:c2:8e:94:34:09:
+                    c3:45:dd:4c:79:03:b8:bf:ce:55:8f:6e:6d:c9:ff:
+                    4c:5b:da:fb:eb:70:bd:c9:37:68:6e:03:e0:db:2f:
+                    6e:db:6c:d4:f0:1f:01:43:42:6e:f6:31:4b:8d:fb:
+                    21:1e:77
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                23:46:34:1C:74:3B:D8:21:40:4D:81:B3:58:9F:57:CB:0C:5E:90:FB
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+    Signature Algorithm: sha256WithRSAEncryption
+         3c:80:ef:a8:a1:94:bc:12:33:6c:19:2e:44:44:6c:20:8e:69:
+         f6:b8:21:ad:4b:f7:14:d6:bf:c3:8d:b0:87:d1:e2:55:df:c0:
+         fd:03:31:82:8a:82:dd:68:3d:61:1f:c4:89:eb:e6:07:b0:89:
+         1d:19:8b:ee:57:9f:87:d8:a2:d8:fe:84:ad:f1:18:9c:b5:93:
+         a1:17:48:41:1e:f7:12:1e:50:46:b7:57:93:6e:d5:0f:d5:84:
+         a8:8e:74:4f:ab:8a:ae:40:64:8a:a8:57:32:75:b6:82:20:10:
+         be:ab:70:0c:96:c7:30:f4:69:c7:c9:24:db:3a:bc:40:eb:ac:
+         ee:04:f3:58:4a:09:6e:42:01:b4:a5:77:e5:2b:01:05:c1:5c:
+         08:59:0b:e3:a9:7a:b4:3e:f9:41:8d:2b:e6:8e:40:27:07:07:
+         0d:b0:03:ba:c9:d2:cd:dd:3c:9a:7e:20:66:bb:7f:4f:9d:fc:
+         37:16:88:84:a1:26:6a:91:43:d1:47:82:cb:e1:84:d4:03:93:
+         ec:8d:14:ce:2c:c8:fc:96:f8:28:d5:cb:89:c8:84:ee:8a:54:
+         8e:3c:12:86:10:73:78:5c:b8:a5:7d:99:94:b1:e1:f9:18:ed:
+         4b:2f:ae:8d:d4:9b:bc:20:21:d3:13:ed:07:15:70:dc:d1:1f:
+         58:22:fc:0e:5a:49:4e:6f:c1:99:9d:de:71:4e:62:7d:ad:d3:
+         2e:c3:ca:3f:db:cf:f3:46:aa:95:1f:99:1c:81:f8:15:5a:a1:
+         30:f7:7b:4a:e1:8a:fa:8b:a4:92:6d:11:e3:4c:f5:2b:b9:a3:
+         6d:a4:07:93:cb:28:f7:06:c1:e8:1b:1e:c5:aa:76:51:7e:1b:
+         a7:fe:db:9b:d4:23:d1:2a:16:52:ed:d1:2c:55:2b:cd:db:73:
+         fa:20:1a:18:47:af:90:50:0c:fe:1b:0d:f6:06:ec:33:1f:8e:
+         6f:f2:9a:d0:49:88:cb:a0:8c:8a:60:54:8e:d0:c1:59:ad:e6:
+         6e:6a:3e:e4:3b:b4:1b:01:8e:81:a4:f2:21:94:d1:a7:5e:e8:
+         1a:14:af:f1:46:5d:6a:ad:9d:06:02:84:58:96:b2:e6:f8:02:
+         5f:ce:ed:87:54:b5:f9:b6:62:97:51:b2:88:05:49:de:fd:56:
+         d1:67:e5:59:78:31:82:36:17:ce:07:62:81:5c:19:82:48:22:
+         88:15:ea:d9:fc:1e:c3:ee:05:a5:ec:e9:ca:69:b5:2a:7e:79:
+         ed:aa:6e:3f:b5:45:75:0b:d4:27:e4:4c:88:04:e0:06:36:5e:
+         41:37:b0:f5:44:80:58:86:dc:c1:be:82:62:fe:a8:2c:6c:ca:
+         6a:f8:dd:fd:85:df:5a:41
+-----BEGIN CERTIFICATE-----
+MIIFUTCCAzmgAwIBAgIQDU4+7gygvhd3Nn4+SL9a8zANBgkqhkiG9w0BAQsFADAT
+MREwDwYDVQQDDAhDaGFuZ2VNZTAeFw0yMzA2MzAxMTQ1MTJaFw0yNTEwMDIxMTQ1
+MTJaMBQxEjAQBgNVBAMMCWNsaWVudC0wMTCCAiIwDQYJKoZIhvcNAQEBBQADggIP
+ADCCAgoCggIBALPvJQ+Gd46fpEIC8BkOIA6TXmd4F5mpzQaE/sHtW8mW0YLvX6WV
+196Zl4TMqCgTaS9BetTwrKejEIoxxqoU3dBdFVEs6V4+/vAc12IH9/sBkyKPS3J3
+dooU/iZSWchZsAG2y3otug01ooxClxhURVjxaf87zv1xpRNCgsriJUNh1jQf9vM2
+f8l9pOKD8Y+3Lc1/zxqQpIbOwGs2s56Q0GBc7Kxw9zIWWSAfJ6U8AKCbYzBBpdNj
+N50Q9/ZTRVRXcH4GpgEyOCwt0RFMP1clWiwsBqAgu8CV/USoDTqwyaOyd8738PXI
+HKd0urmDCzxWbxjL3zl3OmkYV75IfqsqIS2w60wmrpPy2Q0pAbgsC1rsisD9XRyn
+bzEpXVw1zQ7gl4YHr15pjufh8Hgh8xXGNc3mS2XVFwuHbuo5RJarvPzuJ4X+EMR3
+liXNmmbu5Db78MiQYt5t9owZdsZtw5ykn4DsOXm6MjayfZM83FjFEzQ1in7LzPCa
+uzndyrzPx3qPm2DxqObkQWKCzczSgQbBW4IMSYjmvTmyBoKg+1W6/d5XL0CEB7g4
+mkluOEnAuSb3fqmaGLMnudmz+39tnmhYlPexIbXuWbB//A+rAMKOlDQJw0XdTHkD
+uL/OVY9ubcn/TFva++twvck3aG4D4Nsvbtts1PAfAUNCbvYxS437IR53AgMBAAGj
+gZ8wgZwwCQYDVR0TBAIwADAdBgNVHQ4EFgQUI0Y0HHQ72CFATYGzWJ9XywxekPsw
+TgYDVR0jBEcwRYAUmBuw7bvaYZi1OnrIxE4ycKX4qQehF6QVMBMxETAPBgNVBAMM
+CENoYW5nZU1lghQRFLv/ZzUIweAY3+3bxHLwDm1FLDATBgNVHSUEDDAKBggrBgEF
+BQcDAjALBgNVHQ8EBAMCB4AwDQYJKoZIhvcNAQELBQADggIBADyA76ihlLwSM2wZ
+LkREbCCOafa4Ia1L9xTWv8ONsIfR4lXfwP0DMYKKgt1oPWEfxInr5gewiR0Zi+5X
+n4fYotj+hK3xGJy1k6EXSEEe9xIeUEa3V5Nu1Q/VhKiOdE+riq5AZIqoVzJ1toIg
+EL6rcAyWxzD0acfJJNs6vEDrrO4E81hKCW5CAbSld+UrAQXBXAhZC+OperQ++UGN
+K+aOQCcHBw2wA7rJ0s3dPJp+IGa7f0+d/DcWiIShJmqRQ9FHgsvhhNQDk+yNFM4s
+yPyW+CjVy4nIhO6KVI48EoYQc3hcuKV9mZSx4fkY7Usvro3Um7wgIdMT7QcVcNzR
+H1gi/A5aSU5vwZmd3nFOYn2t0y7Dyj/bz/NGqpUfmRyB+BVaoTD3e0rhivqLpJJt
+EeNM9Su5o22kB5PLKPcGwegbHsWqdlF+G6f+25vUI9EqFlLt0SxVK83bc/ogGhhH
+r5BQDP4bDfYG7DMfjm/ymtBJiMugjIpgVI7QwVmt5m5qPuQ7tBsBjoGk8iGU0ade
+6BoUr/FGXWqtnQYChFiWsub4Al/O7YdUtfm2YpdRsogFSd79VtFn5Vl4MYI2F84H
+YoFcGYJIIogV6tn8HsPuBaXs6cpptSp+ee2qbj+1RXUL1CfkTIgE4AY2XkE3sPVE
+gFiG3MG+gmL+qCxsymr43f2F31pB
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQCz7yUPhneOn6RC
+AvAZDiAOk15neBeZqc0GhP7B7VvJltGC71+lldfemZeEzKgoE2kvQXrU8KynoxCK
+McaqFN3QXRVRLOlePv7wHNdiB/f7AZMij0tyd3aKFP4mUlnIWbABtst6LboNNaKM
+QpcYVEVY8Wn/O879caUTQoLK4iVDYdY0H/bzNn/JfaTig/GPty3Nf88akKSGzsBr
+NrOekNBgXOyscPcyFlkgHyelPACgm2MwQaXTYzedEPf2U0VUV3B+BqYBMjgsLdER
+TD9XJVosLAagILvAlf1EqA06sMmjsnfO9/D1yByndLq5gws8Vm8Yy985dzppGFe+
+SH6rKiEtsOtMJq6T8tkNKQG4LAta7IrA/V0cp28xKV1cNc0O4JeGB69eaY7n4fB4
+IfMVxjXN5ktl1RcLh27qOUSWq7z87ieF/hDEd5YlzZpm7uQ2+/DIkGLebfaMGXbG
+bcOcpJ+A7Dl5ujI2sn2TPNxYxRM0NYp+y8zwmrs53cq8z8d6j5tg8ajm5EFigs3M
+0oEGwVuCDEmI5r05sgaCoPtVuv3eVy9AhAe4OJpJbjhJwLkm936pmhizJ7nZs/t/
+bZ5oWJT3sSG17lmwf/wPqwDCjpQ0CcNF3Ux5A7i/zlWPbm3J/0xb2vvrcL3JN2hu
+A+DbL27bbNTwHwFDQm72MUuN+yEedwIDAQABAoICAAuYKlwwvv16vfve8pe6uEgY
+KOoj6+lj7qkv4raeU97OkBuOzyv9VtaqMQBGq8NBVPLNlluoUofO0x8EjBejlpN5
+nAkKCtOe3ZCdWyee+dS7yj5c23C5z/Kf3ayce9qUJOpHXB84WRfGz/2XwOK5c2qC
+y+C9et4L96YhEAqAvgP0hvf+40vSxDM4nGpYNDWdiR8H0FGW5nMlWXLPKI3cKQE8
+m6eU8+jPVdjjCQv1rNisipyubkAL0aaWVFQUE5CWvdHxHbtQABygqyshLaew6XmV
+MKwaz95eC97jsU6J28RnmJ7GjUlZJreHpwyTLCMsMqZ3ZJ/wVdw1zFmflEH1SgPq
+/JNd0OONKm8x7nORX9dHEn33Imfyg2jI6tzVx1oAmMWMb9hJ0XjkIyzjfHTPi5KW
+pM3pTUUn6ee4P1T4ReBlatiw2TFgAd18/9gSIaSlENEjslJGQ6/Ndt9O7UNHgwth
+ZNtPovjNLqUobHGXlmwg3haeBshn9iPcjdksAjgtjEyowzq7IpiSxQezXNcMezGM
+Y9UL5Qc/yjQ3t+Vu94Jmnu0TT3lHGWa3zSgI6L+UdBiIsLF6P5YQVloYOYWE3q/n
+HTaORoZlsRKfMIUHmhrZ1keJ4VGqLruSpQHobh3Cfb/xzgOEB3nSwhIK3l2FhSiR
+N9jb0r7kMElO+xlm7NChAoIBAQDllnlfyWnTBGog8+T9eJiODuBfdozy2vCZO8nc
+vp11NC7fLh5NXR16Ju6I+dcXDhPdoOG8H/DScjer82kEINrY7Wb4swNd01cLCg+/
+xVNe9iiLl4Q4m/QOI6ZOUbOfJjH9R8J4Bh/FzR1MXtVktgtsd6JB3zv6V246zDjy
+eMnOImwoj6TH/3hI/g2s5i3GoaC7CK+XjpdfZbVAX5+mnpZxBbOqXt7an1IzYHhx
+hQO8uo/9b2IDxMrWWn80mGj9Fw5AdK1Ef3eMtbyG6iOIR92UEo9ZwlZ9Tang58Sa
+7IFHZko/HcCrS92Hl9YcnYmjG0GDeFl4des+IcVz0AHDhe6RAoIBAQDIolXgCYO3
+zo2MtoBTCr+GcluT4DD16ALz7wd8/jXFqmD3UWCAeaS5IsTno1PmuIpvB7dvwz8B
+6SOpE//J/bECDmhE18UHYOAqkXzzuuEGMCP1TuaCWBq7kWV8GVTRcSGQDxLyf/Yu
+IdxiPQMaCxi0Ffv+aq27Nii1IyV8tyDL3skyGZeQJNW2xjNkngkXsB5Tp7H7tA0G
+lSmld1Rtq2XWcRnHQh9ZVP+FxwkjBkdoX0oAASVQwHsy9Q4hZ5ykxPkIGULj3Hw5
+zvG1RAM5B4GQegK0OfYuX5Ullrz6a/6p/FnGLvRkZGlHML/bHTmrr8ywSvF63Gkd
+oU0nqjPFQ1CHAoIBACoFR4PDno3TwgTz/tZxqyJdEK4ISbXtYpn5OnIfpTwdZ/LL
+QxqPz2RbGc+SQs7icbpfxtEi23X5F71uGKt7w/JuSSl9wkD6/HR1y/oiiKbZ0QPz
+oGyoBpxL5BVzmLepSv77kllbbZdLenBO7ym2tBKPNvBthlHEjNVQKaAfgXgsDrXB
+zLwaQw7BCQm7O2eej4eMCG9p1sTMHceBePwLDKf1DjRBlvJWtLnYj1LfsJZrYw1U
+xJDCBQoEmEGtH5IrFR2w/UGLPvtPDAl5czVvSdvfJcOc8S2P+GbEpNRiMys5Sp+Q
+t4HiqdI2dSbZoqZqx6vjbCTDGGJP1g7jZF8/9TECggEAXOXVj2O4an4oSnQiXNEI
+N29x+bl/0gy4eUw/El/+c+Tc+wbiAPrSC6sOsxaL/bOK3bgb9pLX9MGHcn1BHbzq
+ncIgA2hI4Y64nN06lvv7v0rBC4+Z6dZzok/DRr/P5x5T5Qklw8T+LwQcsBwB+KgU
+qyXWxUmN4bZFCQIaFHISrHMeg6UX6XU0w2loWHlYSnCQyjlGjv4iXd7pJqVnIVSQ
+VceOoRV7wHg7zCyJjX8Vxzz/3ZqqNYa6RLD09wCrphtSF67iqvDnUDkC7+Rq/Zf9
+JPFpmRuRYo19WKdAH0+r3fdrdfk9zdI0cPMgkosordc7lpFM2I9/2GlceTY0vGzb
+twKCAQEArUbkiwUZFjdjAbKS2m0uPJyytB8bZ335szcoMUV665hzU9EJPcWeVY0L
+1FSRu/cig+ZCmpUEc/4JhJVKLEEXgC3BgfHGNHi5PIuvssMT/fJJ9InQe8n4Zq0Q
+eZbrfAewrdH3bTpEf6AxIsrMioLsUQSV12iRQ7olsEP9t5HqRKqwhAnqp+q33XT3
+L++8IcaaEQ3S/sBb23pY+VSWQfKGFVQES+P7yKeNHjBNQpJTPOdM9iLtvriUmNdO
+Gy5HOpLgd10DzXBOI7CgqzFm69Bqk+WFZXGVd9T/Ku69B8XfshoRChGbgHbbEG70
+0xT4AQEuygYVBbUrIerZFpDD+Tw7ww==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.4.6-alpine-3.9/openvpn/firewall.sh
+++ b/variants/2.4.6-alpine-3.9/openvpn/firewall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# This iptables script to controlling traffic in the openvpn tunnel.
+# In this example, clients can only perform DNS, HTTP and HTTPS requests to the world.
+
+# Drop everything by default from tunnel to world
+iptables -P FORWARD DROP
+# Allow DNS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p udp -m udp --dport 53 -m conntrack --ctstate NEW -j ACCEPT
+# Allow HTTP and HTTPS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p tcp -m tcp -m conntrack --ctstate NEW -m multiport --dports 80,443 -j ACCEPT

--- a/variants/2.4.6-alpine-3.9/openvpn/server.conf
+++ b/variants/2.4.6-alpine-3.9/openvpn/server.conf
@@ -1,0 +1,280 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/server.conf
+port 1194
+proto udp
+dev tun
+server 10.8.0.0 255.255.255.0
+ifconfig-pool-persist tun-ipp.txt
+;client-config-dir ccd
+keepalive 10 120
+comp-lzo no
+max-clients 5
+user nobody
+group nogroup
+persist-key
+persist-tun
+status tun.status
+status-version 3
+;log-append server.log
+verb 4
+mute 20
+;duplicate-cn
+tls-version-min 1.2
+cipher AES-256-CBC
+auth SHA512
+key-direction 0
+;crl-verify crl.pem
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            97:80:c6:6b:b5:84:81:b3:2b:f6:56:55:da:67:4d:c8
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=server
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:be:f7:ee:15:bc:b6:e1:04:28:3e:38:6a:61:dd:
+                    ee:fa:61:85:9a:a7:be:44:22:52:b4:cf:7a:86:0e:
+                    21:ae:1e:2b:61:66:17:1f:54:dc:e9:75:27:55:24:
+                    39:fc:ee:92:d1:da:de:e2:5f:01:50:b6:ae:52:1a:
+                    79:6b:8d:56:0d:83:f6:d4:19:50:48:bc:cb:d8:69:
+                    c8:79:d4:ba:82:05:db:aa:58:12:4b:34:1b:15:d1:
+                    28:2d:b7:08:4e:a0:64:fb:c6:b4:e2:8b:61:68:4e:
+                    72:72:cc:da:a2:d8:cb:f5:6a:5d:13:b6:98:d3:0c:
+                    a3:05:7a:21:e3:f9:fb:de:89:be:37:ac:ce:4c:2e:
+                    95:98:9e:48:3c:04:97:cd:a3:36:92:15:12:a4:bf:
+                    46:ea:95:37:0c:6f:09:e1:51:f5:4e:13:9f:f5:68:
+                    65:0e:24:38:62:04:f8:f9:0c:06:72:c9:03:ed:5d:
+                    6f:40:3b:62:ea:a2:79:01:79:d0:58:aa:2c:7f:89:
+                    14:bc:3e:86:c0:5e:58:ac:58:c0:97:fe:65:57:46:
+                    bf:01:cc:d4:d7:64:d8:21:15:02:6b:6a:38:24:bb:
+                    2b:45:c7:79:23:7a:7f:0c:6b:25:d3:ce:e1:3f:e8:
+                    68:6c:31:7a:df:88:49:6d:a3:7e:22:24:08:3d:e1:
+                    6c:87:dd:34:77:d2:a5:eb:f7:e6:74:b9:e2:5f:e4:
+                    ad:49:e1:c0:b4:8f:d9:b5:ac:2d:7b:ba:22:64:8e:
+                    b7:c1:11:11:f1:e1:1f:b9:3e:29:b1:61:9b:8a:1c:
+                    2e:d4:e4:e6:10:5a:5d:e1:f9:1e:54:7b:13:79:dd:
+                    d9:ad:8b:23:c4:8d:a5:8b:f5:17:eb:99:96:5d:c6:
+                    8d:b4:af:8b:4c:2f:08:4d:37:c3:bf:6d:68:99:c4:
+                    f7:47:cc:5d:44:e7:6e:f2:64:b3:7d:bb:9b:c7:e1:
+                    27:cf:73:8d:b2:e2:88:19:6c:bb:6e:cd:4a:0a:79:
+                    a8:7b:9d:c3:b0:59:93:51:20:a1:d8:a2:0f:e5:62:
+                    76:17:b3:bb:aa:bc:3a:73:e7:f6:57:91:6a:cb:d3:
+                    7e:91:38:5e:88:57:e3:d8:3e:31:cd:dc:69:9a:74:
+                    bb:6e:62:c2:ab:5b:8c:f5:80:ff:b4:98:a2:87:15:
+                    72:38:77:76:dc:e2:d1:ac:2f:66:67:ae:c4:33:a8:
+                    86:94:af:41:b1:99:0d:5d:68:df:9a:ec:86:0f:0a:
+                    c9:67:fa:a1:7c:29:47:d3:f1:c1:3d:8a:d1:a4:12:
+                    a6:70:16:37:80:4f:d9:79:61:45:1c:07:77:68:60:
+                    4e:10:ec:94:dd:03:95:b1:37:cc:88:3d:60:cc:32:
+                    37:be:a5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                4A:91:C2:3E:A1:E9:04:C9:C0:9A:8B:CE:D4:37:4D:96:0E:74:FE:90
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication
+            X509v3 Key Usage:
+                Digital Signature, Key Encipherment
+            X509v3 Subject Alternative Name:
+                DNS:server
+    Signature Algorithm: sha256WithRSAEncryption
+         72:b4:75:02:f7:7b:e9:07:c6:79:1b:bb:11:e4:73:4a:b4:76:
+         1c:03:b9:58:8c:0a:80:f0:c6:8c:cc:2a:a7:c7:8c:57:a8:6e:
+         52:19:f0:b5:7c:0f:06:ab:2f:04:0e:99:32:b9:2c:b6:42:f0:
+         f5:5b:97:32:ce:bb:0c:ee:9f:b0:0b:bc:0b:c0:43:1d:7d:04:
+         b4:a1:cf:a0:aa:fe:f1:cc:b4:31:b3:bb:78:ed:0e:60:8d:37:
+         ea:48:a7:b4:2d:6d:64:6e:97:15:aa:e4:9b:b4:68:79:c8:3b:
+         ba:91:0b:db:cd:04:a3:aa:e4:69:59:06:ec:50:68:6d:0d:a6:
+         38:32:55:76:09:10:00:da:ac:a8:9e:ad:ad:95:8f:01:88:c9:
+         40:af:9a:5c:2d:17:34:81:6b:26:65:8a:e5:2a:15:79:13:2d:
+         ae:d8:03:16:6b:e9:b6:cd:f3:cb:d5:4d:5f:40:76:7a:99:99:
+         d5:2f:e8:a1:59:88:01:6b:a1:36:c0:53:dc:46:07:fd:ab:ab:
+         2a:5b:d3:d5:4c:84:c2:fb:48:16:80:80:01:f6:37:80:3a:54:
+         81:11:24:86:a6:a2:9a:73:06:5f:ca:24:8c:20:3a:40:6e:95:
+         8e:44:46:ef:60:bc:9d:11:ad:71:af:61:85:a6:e2:b4:49:c7:
+         fa:bb:ef:b5:c9:02:d2:a2:a5:3b:f6:46:03:dc:58:9f:ff:dc:
+         23:6b:b5:02:4c:1a:1a:80:99:6d:1a:fd:24:fc:32:83:f7:de:
+         fd:2b:b2:45:b7:3b:89:3c:49:0c:3d:0b:05:67:a5:95:00:3d:
+         cd:a7:0a:3b:b5:cd:02:10:09:de:ff:6c:6b:8b:aa:9d:e6:e9:
+         07:83:e2:dd:de:6d:bc:9e:fd:19:77:30:5d:67:12:c2:33:40:
+         0f:13:69:98:02:ef:05:b2:ad:ef:fb:73:15:57:70:46:83:32:
+         a9:05:4d:31:06:3d:44:93:88:69:de:9a:67:b4:6b:b7:0d:6b:
+         69:24:8b:62:52:f7:85:66:8f:84:2d:c0:a7:ff:33:37:7c:f3:
+         d1:1f:8c:b6:16:a3:98:db:6e:aa:e5:eb:d8:ed:06:31:19:ba:
+         01:f1:e6:3e:bc:78:ec:6e:b4:af:6c:8a:49:0f:ff:5a:f0:00:
+         88:d8:66:af:d6:49:31:b5:54:ce:be:07:59:46:bb:67:73:4b:
+         b8:ec:be:16:04:ed:fe:75:57:21:d6:d5:7b:cc:d0:7c:bd:91:
+         d3:6e:61:72:04:30:24:45:0a:0d:16:b6:35:94:49:02:14:8d:
+         2d:1d:71:42:13:9a:02:1e:3c:31:05:b4:76:5b:dd:ff:bb:db:
+         f4:31:b7:47:bb:54:f8:27
+-----BEGIN CERTIFICATE-----
+MIIFYjCCA0qgAwIBAgIRAJeAxmu1hIGzK/ZWVdpnTcgwDQYJKoZIhvcNAQELBQAw
+EzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMjUxMDAyMTE0
+NTEyWjARMQ8wDQYDVQQDDAZzZXJ2ZXIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+ggIKAoICAQC+9+4VvLbhBCg+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzp
+dSdVJDn87pLR2t7iXwFQtq5SGnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV
+0SgttwhOoGT7xrTii2FoTnJyzNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWY
+nkg8BJfNozaSFRKkv0bqlTcMbwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2Lq
+onkBedBYqix/iRS8PobAXlisWMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8M
+ayXTzuE/6GhsMXrfiElto34iJAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17
+uiJkjrfBERHx4R+5PimxYZuKHC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZd
+xo20r4tMLwhNN8O/bWiZxPdHzF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7
+ncOwWZNRIKHYog/lYnYXs7uqvDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKr
+W4z1gP+0mKKHFXI4d3bc4tGsL2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT
+8cE9itGkEqZwFjeAT9l5YUUcB3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABo4Gy
+MIGvMAkGA1UdEwQCMAAwHQYDVR0OBBYEFEqRwj6h6QTJwJqLztQ3TZYOdP6QME4G
+A1UdIwRHMEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhD
+aGFuZ2VNZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwEwYDVR0lBAwwCgYIKwYBBQUH
+AwEwCwYDVR0PBAQDAgWgMBEGA1UdEQQKMAiCBnNlcnZlcjANBgkqhkiG9w0BAQsF
+AAOCAgEAcrR1Avd76QfGeRu7EeRzSrR2HAO5WIwKgPDGjMwqp8eMV6huUhnwtXwP
+BqsvBA6ZMrkstkLw9VuXMs67DO6fsAu8C8BDHX0EtKHPoKr+8cy0MbO7eO0OYI03
+6kintC1tZG6XFarkm7Roecg7upEL280Eo6rkaVkG7FBobQ2mODJVdgkQANqsqJ6t
+rZWPAYjJQK+aXC0XNIFrJmWK5SoVeRMtrtgDFmvpts3zy9VNX0B2epmZ1S/ooVmI
+AWuhNsBT3EYH/aurKlvT1UyEwvtIFoCAAfY3gDpUgREkhqaimnMGX8okjCA6QG6V
+jkRG72C8nRGtca9hhabitEnH+rvvtckC0qKlO/ZGA9xYn//cI2u1AkwaGoCZbRr9
+JPwyg/fe/SuyRbc7iTxJDD0LBWellQA9zacKO7XNAhAJ3v9sa4uqnebpB4Pi3d5t
+vJ79GXcwXWcSwjNADxNpmALvBbKt7/tzFVdwRoMyqQVNMQY9RJOIad6aZ7Rrtw1r
+aSSLYlL3hWaPhC3Ap/8zN3zz0R+MthajmNtuquXr2O0GMRm6AfHmPrx47G60r2yK
+SQ//WvAAiNhmr9ZJMbVUzr4HWUa7Z3NLuOy+FgTt/nVXIdbVe8zQfL2R025hcgQw
+JEUKDRa2NZRJAhSNLR1xQhOaAh48MQW0dlvd/7vb9DG3R7tU+Cc=
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQC+9+4VvLbhBCg+
+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzpdSdVJDn87pLR2t7iXwFQtq5S
+GnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV0SgttwhOoGT7xrTii2FoTnJy
+zNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWYnkg8BJfNozaSFRKkv0bqlTcM
+bwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2LqonkBedBYqix/iRS8PobAXlis
+WMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8MayXTzuE/6GhsMXrfiElto34i
+JAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17uiJkjrfBERHx4R+5PimxYZuK
+HC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZdxo20r4tMLwhNN8O/bWiZxPdH
+zF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7ncOwWZNRIKHYog/lYnYXs7uq
+vDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKrW4z1gP+0mKKHFXI4d3bc4tGs
+L2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT8cE9itGkEqZwFjeAT9l5YUUc
+B3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABAoICAAnfT1OYWevwBxSQXg+JJZ2U
+BRAls9RZ4eSvBSqA+ITD0oJKgM+B15nKEKp6IPVOcBChO/x/5NWDXCeqbrR8rgIs
+3EnCtT/NYsxhS5fgw3ONUfnQa8Gvg+bw1R7n42oNKKtLbnZ3tiVqSMhehr78bi7V
+vNIUEnp2oMbbtXzPo5GxlT/TkyalEd698AYKRr6+vUd4B2q06Lmf1SSzaNNZJVFP
++mj5aJ/+h1up3iUh1gOBGM7gkavEZiyzEYZeAcNTqNE/CO9iXBz9w5/FRs+UuzBz
+29P//tDTyciMCX/8EcL0WhxVX5HR91dxApecjlB7d0qAlFWR+hnM5exl6HcqfC3C
++Uhi5IC+gZjD2KCcHDr9e5WqQ6cu8TeMnoyuHInIV9kUL3Bn1ArOU1dmGS78soeE
+GpqGCRc9Imh8jxs1AVyj9wGzpfuRS8OBpfR5MIlcFwSlZO/6dnJSaF2BH1jnKgBG
+Xn9MvjfHTU/EhLTteXrAJlqQr4e/uAK5QCESFNXLvC0r3qord6b9Y0zHR63SpESJ
+WVUIF9L2fIh0Z4CutPegcbEyWLaaAT4njyR4uCI78g77kK+PGi2NM65Mk+wKt975
+m3Qh4/cNv1ews4h+RflayWC9kiiRVzDHJGTy63k5gdplqrW2rb8gK3ZQaT2gQp9u
+gjKIIFGyi+EIDSukHNdRAoIBAQDuGvE9k1lSvoPgSusogMk7PWTiZbn8MwlEFueM
+ZJk9k8dMSkqF1k5BXG9lHcWuFl2invgTiFJIF7ML0GDsFJR+CzCDsanSGdjyKfGM
+HzHAc7UPAJYBXPX1rxTAhGSirKjArcqYUX3ZGGaTo1yZrsbbarInUhWWNKFBdaQ+
++L3oClGt3GZx7hdxapI/3gnkLvG/C5hWWetLONZAxY6jwJJSA/p2Fx93SlWOtrmT
+KRbM/p8m6sHtsXcBnYTueqWYpJ2mnBIB+Svf5acqQ2Xf8kAIw4Vw9u7a15OlIDGF
+ouWhtSkL4s0YfZjlXswOPZDlF3eT2ilf+OIjv5kEcLdDKOojAoIBAQDNUhfys2TH
+b1NFsIH6X1jtWHUEGOYIM/y/75Vw2pGLb40cMxVPtzsNCvz8id/sCuvx6yUWlBlN
+wjpa+7dOA+FgoXwv1iVsQm1zQlrt2VKaEy29C0tRkSwOjNC0bz1409wzYNnh5Bdx
+KJDvSz9zlefAryJGTSgGOothOjnguzoEJ6DxfkxNyWbxceBgN8JljDhc9dcybKdD
+Uxy2GflXhZvZfCtTbYfWoIV+dTYyZt2QE4PEPXrJHGUFE9ncGynbzAn1Cc/zGBeT
+zFNoYOCWNr7ueRNHQYMRZ1N3dYRdZ9th5mdqqa1eY5lP4PyQYZV6lwmyEfitXwNz
+vhS0sO+pNAyXAoIBAB9OiZOoESGRDTPrhdnwfQT+AIrIB1lCuKAsRsut2nw/NwAv
+8HaChA2SAs+Px5MpO6yLLGEdFnyGKTOPdX71AcVE4V8feA24+k50916OJ3N/gzny
+wMZzG5/vIlJh1f2RqCqVb0LxzBNEYxBcdWt7kIf/EmebIl16lA1QU4U4HXgqCy1K
+AmpOfOSbt5kQL8rB5WVSN/h6oDZmxb0EfMnJIzQHc+IdDjUYIAHAwsu3pljTzcdH
+LLJ9GAGtXXIhzC4yzsu+T5vU0FEDGCS1ceqtJoBAfQYqYaOCntYiUoCYt4q4kCoQ
+6xiiQv09pqTksW191WoqUDBfQBSlN5Be5am98nMCggEAIzEb+7R15J0XN82uKZzo
+IB5WSDKAUw2eF8PX6HT+F1kyZY/36ibszyp//EUhhVLF6Dw2qi0OPT66Q9f7LjsK
+CUcEgyqAVZL5MZVBAp2KQ/BfmZRy/3MTixbluteKQMiHaKMEFWzD+9hJJ0rNgGFE
+TMl35XbaEl88fpi9TOCqbAXi1yGfsIGBzIaJP9Su1Dr5ei2FChaHgMmhFTFUhITZ
+FqjqwCz46HexCeDLPk5VUZmWry8eeZQNWJZzc/+P6CWL210oMHGDsQiHj09zjyup
+BDTqcf8vmO8N5l7VJjFj797PAQA+P/xwTbmxcInZVh7HQadE6WpsrAz7fZEKMwVB
+1wKCAQEA3oqXI9bGGoXFjydUiNMZbuHdIDQCa9t7iDb+J+NAiA7GI8W8DlFYrUST
+S/CoBey/WOW9jPT/A8EBnp8RmPtAJH88qklbqh/YCoKyKZrgqT5IGysRLWwDFrGT
+QoOvR1a6SaVMLskmYUCkl8Yz8sZS58X50ahxx5TB0I3xsoCmnMZt+cd2C/VXwhFz
+jCiEZIuQlSgQFW4LOFrxrXmI+MDOBWu4zvkztWOnTe+BNgrxndGVI6sdFGzWeNQx
+dQ9imn0UqGSkgnJEj7Lq67ey8Cuu6yYWexKI0N9UOcyL4FgaEdWiJ0t5KY6NElGI
+0jrZX7pwVf/pvbKW2zVm6nXjWJ/JFw==
+-----END PRIVATE KEY-----
+</key>
+<dh>
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEAqJI9Luwkfy0E95gqZyq031Fa1rUCW5aBoppgm4YHxGUL+fUQzveF
+U2+W5xzmZuxhyoN0PVqlPXoMi0xGyTW4ga8qMaIHDqQ/V8RNxQYJ+GEEiC46/2u9
+Co/HbGX9YXMm5nnNEtHepAHcJiRB6QbCjzVm06x5QfWifj/yTm9ycVfJXhQJiOkD
+j4y4vJbgrmIKWX8Nxj4Q8dCAJzZ2gFvMnW9XcbS9SYbyvS0DvoQG3gPTGcopv7x1
+NiOhrxcTcMjwi/2z6kxG0MJEZ1HOJ2xTtRReUGXkL0lhbVTzkX4V6ihWK4MZYqe+
+ozy/0gbPAB4dT1QNeSRXPOi9f81Oed0SoC83P0oiq3JRQq2g7aS9OiwqlRPnVnvH
+q7Uko6+nv8XLbANgbdLXc8I3K78TSedwofxI/atxKncEic0fHV5ai2IdEWt22qxj
+iWVyaiHlWtMosZvuepSPn3cAmfuj0dVPNiRoG97neN8XIOaVZNGmNnI4yM0JEA1h
+Ef4Lh4YpDdqk4Q/nC/zJev8PM1XC+Os1SsGH50YAn8q19TGzI26/Y4jWfqrHswsj
+6vF/lxDS5RRzLIqlEksm84MU1q0AFSe9FaW1NTtKR/PLO1QiSKr718BwzzrDNN9u
+KZJabQ9n1RgLSuMP9zk9A6GUPQ7cZ0fJchUPeuF8Cd7zAV7k4m0RA4MCAQI=
+-----END DH PARAMETERS-----
+</dh>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.5.8-alpine-3.17/Dockerfile
+++ b/variants/2.5.8-alpine-3.17/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.17
+
+RUN apk add --no-cache openvpn~=2.5.8 iptables
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/2.5.8-alpine-3.17/docker-compose.yml
+++ b/variants/2.5.8-alpine-3.17/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '2.1'
+services:
+  openvpn-server:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
+      - NAT_MASQUERADE=1
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/server.conf:/etc/openvpn/server.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    ports:
+      - 1194:1194/udp
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped

--- a/variants/2.5.8-alpine-3.17/docker-entrypoint.sh
+++ b/variants/2.5.8-alpine-3.17/docker-entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+# Env vars
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
+OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
+NAT=${NAT:-1}
+NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
+CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    echo "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
+
+# If no args are passed, run the entrypoint. If a flag is passed, run openvpn directly. Else, run the passed command
+if [ "$#" -eq 0 ]; then
+    # Provision
+    echo "Provisioning tun device"
+    mkdir -p /dev/net
+    if [ ! -c /dev/net/tun ]; then
+        mknod /dev/net/tun c 10 200
+    fi
+    if [ -f "$CUSTOM_FIREWALL_SCRIPT" ]; then
+        echo "Executing custom firewall script: $CUSTOM_FIREWALL_SCRIPT"
+        . "$CUSTOM_FIREWALL_SCRIPT"
+    else
+        echo "Not executing custom firewall script $CUSTOM_FIREWALL_SCRIPT because it does not exist"
+    fi
+    if [ "$NAT" = 1 ]; then
+        echo "NAT is enabled"
+        echo "Provisioning NAT iptables rules"
+        echo "NAT_INTERFACE: $NAT_INTERFACE"
+        if [ "$NAT_MASQUERADE" = 1 ]; then
+            echo "NAT_MASQUERADE is enabled"
+            iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+            if [ -n "$OPENVPN_ROUTES" ]; then
+                echo "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+                for r in $OPENVPN_ROUTES; do
+                    iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+                done
+            else
+                echo "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+            fi
+        else
+            echo "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
+        fi
+    else
+        echo "NAT is disabled."
+        echo "Not adding NAT iptables rules"
+    fi
+
+    echo "Listing iptables rules:"
+    iptables -L -nv
+    echo "Listing iptables NAT rules:"
+    iptables -L -nv -t nat
+
+    # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
+    set openvpn --cd /etc/openvpn --config "$OPENVPN_CONFIG_FILE"
+    echo "openvpn command line: $@"
+    exec "$@"
+elif [ "$#" -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    echo "openvpn command line: $@"
+    exec openvpn "$@"
+fi
+
+exec "$@"

--- a/variants/2.5.8-alpine-3.17/openvpn/client.conf
+++ b/variants/2.5.8-alpine-3.17/openvpn/client.conf
@@ -1,0 +1,258 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/client.conf
+client
+dev tun
+proto udp
+remote openvpn-server 1194
+remote-random
+# Push all traffic into the tunnel
+;redirect-gateway def1 bypass-dhcp
+resolv-retry infinite
+nobind
+user nobody
+group nobody
+persist-key
+persist-tun
+remote-cert-tls server
+cipher AES-256-CBC
+auth SHA512
+comp-lzo
+verb 4
+key-direction 1
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:4e:3e:ee:0c:a0:be:17:77:36:7e:3e:48:bf:5a:f3
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=client-01
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:b3:ef:25:0f:86:77:8e:9f:a4:42:02:f0:19:0e:
+                    20:0e:93:5e:67:78:17:99:a9:cd:06:84:fe:c1:ed:
+                    5b:c9:96:d1:82:ef:5f:a5:95:d7:de:99:97:84:cc:
+                    a8:28:13:69:2f:41:7a:d4:f0:ac:a7:a3:10:8a:31:
+                    c6:aa:14:dd:d0:5d:15:51:2c:e9:5e:3e:fe:f0:1c:
+                    d7:62:07:f7:fb:01:93:22:8f:4b:72:77:76:8a:14:
+                    fe:26:52:59:c8:59:b0:01:b6:cb:7a:2d:ba:0d:35:
+                    a2:8c:42:97:18:54:45:58:f1:69:ff:3b:ce:fd:71:
+                    a5:13:42:82:ca:e2:25:43:61:d6:34:1f:f6:f3:36:
+                    7f:c9:7d:a4:e2:83:f1:8f:b7:2d:cd:7f:cf:1a:90:
+                    a4:86:ce:c0:6b:36:b3:9e:90:d0:60:5c:ec:ac:70:
+                    f7:32:16:59:20:1f:27:a5:3c:00:a0:9b:63:30:41:
+                    a5:d3:63:37:9d:10:f7:f6:53:45:54:57:70:7e:06:
+                    a6:01:32:38:2c:2d:d1:11:4c:3f:57:25:5a:2c:2c:
+                    06:a0:20:bb:c0:95:fd:44:a8:0d:3a:b0:c9:a3:b2:
+                    77:ce:f7:f0:f5:c8:1c:a7:74:ba:b9:83:0b:3c:56:
+                    6f:18:cb:df:39:77:3a:69:18:57:be:48:7e:ab:2a:
+                    21:2d:b0:eb:4c:26:ae:93:f2:d9:0d:29:01:b8:2c:
+                    0b:5a:ec:8a:c0:fd:5d:1c:a7:6f:31:29:5d:5c:35:
+                    cd:0e:e0:97:86:07:af:5e:69:8e:e7:e1:f0:78:21:
+                    f3:15:c6:35:cd:e6:4b:65:d5:17:0b:87:6e:ea:39:
+                    44:96:ab:bc:fc:ee:27:85:fe:10:c4:77:96:25:cd:
+                    9a:66:ee:e4:36:fb:f0:c8:90:62:de:6d:f6:8c:19:
+                    76:c6:6d:c3:9c:a4:9f:80:ec:39:79:ba:32:36:b2:
+                    7d:93:3c:dc:58:c5:13:34:35:8a:7e:cb:cc:f0:9a:
+                    bb:39:dd:ca:bc:cf:c7:7a:8f:9b:60:f1:a8:e6:e4:
+                    41:62:82:cd:cc:d2:81:06:c1:5b:82:0c:49:88:e6:
+                    bd:39:b2:06:82:a0:fb:55:ba:fd:de:57:2f:40:84:
+                    07:b8:38:9a:49:6e:38:49:c0:b9:26:f7:7e:a9:9a:
+                    18:b3:27:b9:d9:b3:fb:7f:6d:9e:68:58:94:f7:b1:
+                    21:b5:ee:59:b0:7f:fc:0f:ab:00:c2:8e:94:34:09:
+                    c3:45:dd:4c:79:03:b8:bf:ce:55:8f:6e:6d:c9:ff:
+                    4c:5b:da:fb:eb:70:bd:c9:37:68:6e:03:e0:db:2f:
+                    6e:db:6c:d4:f0:1f:01:43:42:6e:f6:31:4b:8d:fb:
+                    21:1e:77
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                23:46:34:1C:74:3B:D8:21:40:4D:81:B3:58:9F:57:CB:0C:5E:90:FB
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+    Signature Algorithm: sha256WithRSAEncryption
+         3c:80:ef:a8:a1:94:bc:12:33:6c:19:2e:44:44:6c:20:8e:69:
+         f6:b8:21:ad:4b:f7:14:d6:bf:c3:8d:b0:87:d1:e2:55:df:c0:
+         fd:03:31:82:8a:82:dd:68:3d:61:1f:c4:89:eb:e6:07:b0:89:
+         1d:19:8b:ee:57:9f:87:d8:a2:d8:fe:84:ad:f1:18:9c:b5:93:
+         a1:17:48:41:1e:f7:12:1e:50:46:b7:57:93:6e:d5:0f:d5:84:
+         a8:8e:74:4f:ab:8a:ae:40:64:8a:a8:57:32:75:b6:82:20:10:
+         be:ab:70:0c:96:c7:30:f4:69:c7:c9:24:db:3a:bc:40:eb:ac:
+         ee:04:f3:58:4a:09:6e:42:01:b4:a5:77:e5:2b:01:05:c1:5c:
+         08:59:0b:e3:a9:7a:b4:3e:f9:41:8d:2b:e6:8e:40:27:07:07:
+         0d:b0:03:ba:c9:d2:cd:dd:3c:9a:7e:20:66:bb:7f:4f:9d:fc:
+         37:16:88:84:a1:26:6a:91:43:d1:47:82:cb:e1:84:d4:03:93:
+         ec:8d:14:ce:2c:c8:fc:96:f8:28:d5:cb:89:c8:84:ee:8a:54:
+         8e:3c:12:86:10:73:78:5c:b8:a5:7d:99:94:b1:e1:f9:18:ed:
+         4b:2f:ae:8d:d4:9b:bc:20:21:d3:13:ed:07:15:70:dc:d1:1f:
+         58:22:fc:0e:5a:49:4e:6f:c1:99:9d:de:71:4e:62:7d:ad:d3:
+         2e:c3:ca:3f:db:cf:f3:46:aa:95:1f:99:1c:81:f8:15:5a:a1:
+         30:f7:7b:4a:e1:8a:fa:8b:a4:92:6d:11:e3:4c:f5:2b:b9:a3:
+         6d:a4:07:93:cb:28:f7:06:c1:e8:1b:1e:c5:aa:76:51:7e:1b:
+         a7:fe:db:9b:d4:23:d1:2a:16:52:ed:d1:2c:55:2b:cd:db:73:
+         fa:20:1a:18:47:af:90:50:0c:fe:1b:0d:f6:06:ec:33:1f:8e:
+         6f:f2:9a:d0:49:88:cb:a0:8c:8a:60:54:8e:d0:c1:59:ad:e6:
+         6e:6a:3e:e4:3b:b4:1b:01:8e:81:a4:f2:21:94:d1:a7:5e:e8:
+         1a:14:af:f1:46:5d:6a:ad:9d:06:02:84:58:96:b2:e6:f8:02:
+         5f:ce:ed:87:54:b5:f9:b6:62:97:51:b2:88:05:49:de:fd:56:
+         d1:67:e5:59:78:31:82:36:17:ce:07:62:81:5c:19:82:48:22:
+         88:15:ea:d9:fc:1e:c3:ee:05:a5:ec:e9:ca:69:b5:2a:7e:79:
+         ed:aa:6e:3f:b5:45:75:0b:d4:27:e4:4c:88:04:e0:06:36:5e:
+         41:37:b0:f5:44:80:58:86:dc:c1:be:82:62:fe:a8:2c:6c:ca:
+         6a:f8:dd:fd:85:df:5a:41
+-----BEGIN CERTIFICATE-----
+MIIFUTCCAzmgAwIBAgIQDU4+7gygvhd3Nn4+SL9a8zANBgkqhkiG9w0BAQsFADAT
+MREwDwYDVQQDDAhDaGFuZ2VNZTAeFw0yMzA2MzAxMTQ1MTJaFw0yNTEwMDIxMTQ1
+MTJaMBQxEjAQBgNVBAMMCWNsaWVudC0wMTCCAiIwDQYJKoZIhvcNAQEBBQADggIP
+ADCCAgoCggIBALPvJQ+Gd46fpEIC8BkOIA6TXmd4F5mpzQaE/sHtW8mW0YLvX6WV
+196Zl4TMqCgTaS9BetTwrKejEIoxxqoU3dBdFVEs6V4+/vAc12IH9/sBkyKPS3J3
+dooU/iZSWchZsAG2y3otug01ooxClxhURVjxaf87zv1xpRNCgsriJUNh1jQf9vM2
+f8l9pOKD8Y+3Lc1/zxqQpIbOwGs2s56Q0GBc7Kxw9zIWWSAfJ6U8AKCbYzBBpdNj
+N50Q9/ZTRVRXcH4GpgEyOCwt0RFMP1clWiwsBqAgu8CV/USoDTqwyaOyd8738PXI
+HKd0urmDCzxWbxjL3zl3OmkYV75IfqsqIS2w60wmrpPy2Q0pAbgsC1rsisD9XRyn
+bzEpXVw1zQ7gl4YHr15pjufh8Hgh8xXGNc3mS2XVFwuHbuo5RJarvPzuJ4X+EMR3
+liXNmmbu5Db78MiQYt5t9owZdsZtw5ykn4DsOXm6MjayfZM83FjFEzQ1in7LzPCa
+uzndyrzPx3qPm2DxqObkQWKCzczSgQbBW4IMSYjmvTmyBoKg+1W6/d5XL0CEB7g4
+mkluOEnAuSb3fqmaGLMnudmz+39tnmhYlPexIbXuWbB//A+rAMKOlDQJw0XdTHkD
+uL/OVY9ubcn/TFva++twvck3aG4D4Nsvbtts1PAfAUNCbvYxS437IR53AgMBAAGj
+gZ8wgZwwCQYDVR0TBAIwADAdBgNVHQ4EFgQUI0Y0HHQ72CFATYGzWJ9XywxekPsw
+TgYDVR0jBEcwRYAUmBuw7bvaYZi1OnrIxE4ycKX4qQehF6QVMBMxETAPBgNVBAMM
+CENoYW5nZU1lghQRFLv/ZzUIweAY3+3bxHLwDm1FLDATBgNVHSUEDDAKBggrBgEF
+BQcDAjALBgNVHQ8EBAMCB4AwDQYJKoZIhvcNAQELBQADggIBADyA76ihlLwSM2wZ
+LkREbCCOafa4Ia1L9xTWv8ONsIfR4lXfwP0DMYKKgt1oPWEfxInr5gewiR0Zi+5X
+n4fYotj+hK3xGJy1k6EXSEEe9xIeUEa3V5Nu1Q/VhKiOdE+riq5AZIqoVzJ1toIg
+EL6rcAyWxzD0acfJJNs6vEDrrO4E81hKCW5CAbSld+UrAQXBXAhZC+OperQ++UGN
+K+aOQCcHBw2wA7rJ0s3dPJp+IGa7f0+d/DcWiIShJmqRQ9FHgsvhhNQDk+yNFM4s
+yPyW+CjVy4nIhO6KVI48EoYQc3hcuKV9mZSx4fkY7Usvro3Um7wgIdMT7QcVcNzR
+H1gi/A5aSU5vwZmd3nFOYn2t0y7Dyj/bz/NGqpUfmRyB+BVaoTD3e0rhivqLpJJt
+EeNM9Su5o22kB5PLKPcGwegbHsWqdlF+G6f+25vUI9EqFlLt0SxVK83bc/ogGhhH
+r5BQDP4bDfYG7DMfjm/ymtBJiMugjIpgVI7QwVmt5m5qPuQ7tBsBjoGk8iGU0ade
+6BoUr/FGXWqtnQYChFiWsub4Al/O7YdUtfm2YpdRsogFSd79VtFn5Vl4MYI2F84H
+YoFcGYJIIogV6tn8HsPuBaXs6cpptSp+ee2qbj+1RXUL1CfkTIgE4AY2XkE3sPVE
+gFiG3MG+gmL+qCxsymr43f2F31pB
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQCz7yUPhneOn6RC
+AvAZDiAOk15neBeZqc0GhP7B7VvJltGC71+lldfemZeEzKgoE2kvQXrU8KynoxCK
+McaqFN3QXRVRLOlePv7wHNdiB/f7AZMij0tyd3aKFP4mUlnIWbABtst6LboNNaKM
+QpcYVEVY8Wn/O879caUTQoLK4iVDYdY0H/bzNn/JfaTig/GPty3Nf88akKSGzsBr
+NrOekNBgXOyscPcyFlkgHyelPACgm2MwQaXTYzedEPf2U0VUV3B+BqYBMjgsLdER
+TD9XJVosLAagILvAlf1EqA06sMmjsnfO9/D1yByndLq5gws8Vm8Yy985dzppGFe+
+SH6rKiEtsOtMJq6T8tkNKQG4LAta7IrA/V0cp28xKV1cNc0O4JeGB69eaY7n4fB4
+IfMVxjXN5ktl1RcLh27qOUSWq7z87ieF/hDEd5YlzZpm7uQ2+/DIkGLebfaMGXbG
+bcOcpJ+A7Dl5ujI2sn2TPNxYxRM0NYp+y8zwmrs53cq8z8d6j5tg8ajm5EFigs3M
+0oEGwVuCDEmI5r05sgaCoPtVuv3eVy9AhAe4OJpJbjhJwLkm936pmhizJ7nZs/t/
+bZ5oWJT3sSG17lmwf/wPqwDCjpQ0CcNF3Ux5A7i/zlWPbm3J/0xb2vvrcL3JN2hu
+A+DbL27bbNTwHwFDQm72MUuN+yEedwIDAQABAoICAAuYKlwwvv16vfve8pe6uEgY
+KOoj6+lj7qkv4raeU97OkBuOzyv9VtaqMQBGq8NBVPLNlluoUofO0x8EjBejlpN5
+nAkKCtOe3ZCdWyee+dS7yj5c23C5z/Kf3ayce9qUJOpHXB84WRfGz/2XwOK5c2qC
+y+C9et4L96YhEAqAvgP0hvf+40vSxDM4nGpYNDWdiR8H0FGW5nMlWXLPKI3cKQE8
+m6eU8+jPVdjjCQv1rNisipyubkAL0aaWVFQUE5CWvdHxHbtQABygqyshLaew6XmV
+MKwaz95eC97jsU6J28RnmJ7GjUlZJreHpwyTLCMsMqZ3ZJ/wVdw1zFmflEH1SgPq
+/JNd0OONKm8x7nORX9dHEn33Imfyg2jI6tzVx1oAmMWMb9hJ0XjkIyzjfHTPi5KW
+pM3pTUUn6ee4P1T4ReBlatiw2TFgAd18/9gSIaSlENEjslJGQ6/Ndt9O7UNHgwth
+ZNtPovjNLqUobHGXlmwg3haeBshn9iPcjdksAjgtjEyowzq7IpiSxQezXNcMezGM
+Y9UL5Qc/yjQ3t+Vu94Jmnu0TT3lHGWa3zSgI6L+UdBiIsLF6P5YQVloYOYWE3q/n
+HTaORoZlsRKfMIUHmhrZ1keJ4VGqLruSpQHobh3Cfb/xzgOEB3nSwhIK3l2FhSiR
+N9jb0r7kMElO+xlm7NChAoIBAQDllnlfyWnTBGog8+T9eJiODuBfdozy2vCZO8nc
+vp11NC7fLh5NXR16Ju6I+dcXDhPdoOG8H/DScjer82kEINrY7Wb4swNd01cLCg+/
+xVNe9iiLl4Q4m/QOI6ZOUbOfJjH9R8J4Bh/FzR1MXtVktgtsd6JB3zv6V246zDjy
+eMnOImwoj6TH/3hI/g2s5i3GoaC7CK+XjpdfZbVAX5+mnpZxBbOqXt7an1IzYHhx
+hQO8uo/9b2IDxMrWWn80mGj9Fw5AdK1Ef3eMtbyG6iOIR92UEo9ZwlZ9Tang58Sa
+7IFHZko/HcCrS92Hl9YcnYmjG0GDeFl4des+IcVz0AHDhe6RAoIBAQDIolXgCYO3
+zo2MtoBTCr+GcluT4DD16ALz7wd8/jXFqmD3UWCAeaS5IsTno1PmuIpvB7dvwz8B
+6SOpE//J/bECDmhE18UHYOAqkXzzuuEGMCP1TuaCWBq7kWV8GVTRcSGQDxLyf/Yu
+IdxiPQMaCxi0Ffv+aq27Nii1IyV8tyDL3skyGZeQJNW2xjNkngkXsB5Tp7H7tA0G
+lSmld1Rtq2XWcRnHQh9ZVP+FxwkjBkdoX0oAASVQwHsy9Q4hZ5ykxPkIGULj3Hw5
+zvG1RAM5B4GQegK0OfYuX5Ullrz6a/6p/FnGLvRkZGlHML/bHTmrr8ywSvF63Gkd
+oU0nqjPFQ1CHAoIBACoFR4PDno3TwgTz/tZxqyJdEK4ISbXtYpn5OnIfpTwdZ/LL
+QxqPz2RbGc+SQs7icbpfxtEi23X5F71uGKt7w/JuSSl9wkD6/HR1y/oiiKbZ0QPz
+oGyoBpxL5BVzmLepSv77kllbbZdLenBO7ym2tBKPNvBthlHEjNVQKaAfgXgsDrXB
+zLwaQw7BCQm7O2eej4eMCG9p1sTMHceBePwLDKf1DjRBlvJWtLnYj1LfsJZrYw1U
+xJDCBQoEmEGtH5IrFR2w/UGLPvtPDAl5czVvSdvfJcOc8S2P+GbEpNRiMys5Sp+Q
+t4HiqdI2dSbZoqZqx6vjbCTDGGJP1g7jZF8/9TECggEAXOXVj2O4an4oSnQiXNEI
+N29x+bl/0gy4eUw/El/+c+Tc+wbiAPrSC6sOsxaL/bOK3bgb9pLX9MGHcn1BHbzq
+ncIgA2hI4Y64nN06lvv7v0rBC4+Z6dZzok/DRr/P5x5T5Qklw8T+LwQcsBwB+KgU
+qyXWxUmN4bZFCQIaFHISrHMeg6UX6XU0w2loWHlYSnCQyjlGjv4iXd7pJqVnIVSQ
+VceOoRV7wHg7zCyJjX8Vxzz/3ZqqNYa6RLD09wCrphtSF67iqvDnUDkC7+Rq/Zf9
+JPFpmRuRYo19WKdAH0+r3fdrdfk9zdI0cPMgkosordc7lpFM2I9/2GlceTY0vGzb
+twKCAQEArUbkiwUZFjdjAbKS2m0uPJyytB8bZ335szcoMUV665hzU9EJPcWeVY0L
+1FSRu/cig+ZCmpUEc/4JhJVKLEEXgC3BgfHGNHi5PIuvssMT/fJJ9InQe8n4Zq0Q
+eZbrfAewrdH3bTpEf6AxIsrMioLsUQSV12iRQ7olsEP9t5HqRKqwhAnqp+q33XT3
+L++8IcaaEQ3S/sBb23pY+VSWQfKGFVQES+P7yKeNHjBNQpJTPOdM9iLtvriUmNdO
+Gy5HOpLgd10DzXBOI7CgqzFm69Bqk+WFZXGVd9T/Ku69B8XfshoRChGbgHbbEG70
+0xT4AQEuygYVBbUrIerZFpDD+Tw7ww==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.5.8-alpine-3.17/openvpn/firewall.sh
+++ b/variants/2.5.8-alpine-3.17/openvpn/firewall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# This iptables script to controlling traffic in the openvpn tunnel.
+# In this example, clients can only perform DNS, HTTP and HTTPS requests to the world.
+
+# Drop everything by default from tunnel to world
+iptables -P FORWARD DROP
+# Allow DNS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p udp -m udp --dport 53 -m conntrack --ctstate NEW -j ACCEPT
+# Allow HTTP and HTTPS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p tcp -m tcp -m conntrack --ctstate NEW -m multiport --dports 80,443 -j ACCEPT

--- a/variants/2.5.8-alpine-3.17/openvpn/server.conf
+++ b/variants/2.5.8-alpine-3.17/openvpn/server.conf
@@ -1,0 +1,280 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/server.conf
+port 1194
+proto udp
+dev tun
+server 10.8.0.0 255.255.255.0
+ifconfig-pool-persist tun-ipp.txt
+;client-config-dir ccd
+keepalive 10 120
+comp-lzo no
+max-clients 5
+user nobody
+group nogroup
+persist-key
+persist-tun
+status tun.status
+status-version 3
+;log-append server.log
+verb 4
+mute 20
+;duplicate-cn
+tls-version-min 1.2
+cipher AES-256-CBC
+auth SHA512
+key-direction 0
+;crl-verify crl.pem
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            97:80:c6:6b:b5:84:81:b3:2b:f6:56:55:da:67:4d:c8
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=server
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:be:f7:ee:15:bc:b6:e1:04:28:3e:38:6a:61:dd:
+                    ee:fa:61:85:9a:a7:be:44:22:52:b4:cf:7a:86:0e:
+                    21:ae:1e:2b:61:66:17:1f:54:dc:e9:75:27:55:24:
+                    39:fc:ee:92:d1:da:de:e2:5f:01:50:b6:ae:52:1a:
+                    79:6b:8d:56:0d:83:f6:d4:19:50:48:bc:cb:d8:69:
+                    c8:79:d4:ba:82:05:db:aa:58:12:4b:34:1b:15:d1:
+                    28:2d:b7:08:4e:a0:64:fb:c6:b4:e2:8b:61:68:4e:
+                    72:72:cc:da:a2:d8:cb:f5:6a:5d:13:b6:98:d3:0c:
+                    a3:05:7a:21:e3:f9:fb:de:89:be:37:ac:ce:4c:2e:
+                    95:98:9e:48:3c:04:97:cd:a3:36:92:15:12:a4:bf:
+                    46:ea:95:37:0c:6f:09:e1:51:f5:4e:13:9f:f5:68:
+                    65:0e:24:38:62:04:f8:f9:0c:06:72:c9:03:ed:5d:
+                    6f:40:3b:62:ea:a2:79:01:79:d0:58:aa:2c:7f:89:
+                    14:bc:3e:86:c0:5e:58:ac:58:c0:97:fe:65:57:46:
+                    bf:01:cc:d4:d7:64:d8:21:15:02:6b:6a:38:24:bb:
+                    2b:45:c7:79:23:7a:7f:0c:6b:25:d3:ce:e1:3f:e8:
+                    68:6c:31:7a:df:88:49:6d:a3:7e:22:24:08:3d:e1:
+                    6c:87:dd:34:77:d2:a5:eb:f7:e6:74:b9:e2:5f:e4:
+                    ad:49:e1:c0:b4:8f:d9:b5:ac:2d:7b:ba:22:64:8e:
+                    b7:c1:11:11:f1:e1:1f:b9:3e:29:b1:61:9b:8a:1c:
+                    2e:d4:e4:e6:10:5a:5d:e1:f9:1e:54:7b:13:79:dd:
+                    d9:ad:8b:23:c4:8d:a5:8b:f5:17:eb:99:96:5d:c6:
+                    8d:b4:af:8b:4c:2f:08:4d:37:c3:bf:6d:68:99:c4:
+                    f7:47:cc:5d:44:e7:6e:f2:64:b3:7d:bb:9b:c7:e1:
+                    27:cf:73:8d:b2:e2:88:19:6c:bb:6e:cd:4a:0a:79:
+                    a8:7b:9d:c3:b0:59:93:51:20:a1:d8:a2:0f:e5:62:
+                    76:17:b3:bb:aa:bc:3a:73:e7:f6:57:91:6a:cb:d3:
+                    7e:91:38:5e:88:57:e3:d8:3e:31:cd:dc:69:9a:74:
+                    bb:6e:62:c2:ab:5b:8c:f5:80:ff:b4:98:a2:87:15:
+                    72:38:77:76:dc:e2:d1:ac:2f:66:67:ae:c4:33:a8:
+                    86:94:af:41:b1:99:0d:5d:68:df:9a:ec:86:0f:0a:
+                    c9:67:fa:a1:7c:29:47:d3:f1:c1:3d:8a:d1:a4:12:
+                    a6:70:16:37:80:4f:d9:79:61:45:1c:07:77:68:60:
+                    4e:10:ec:94:dd:03:95:b1:37:cc:88:3d:60:cc:32:
+                    37:be:a5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                4A:91:C2:3E:A1:E9:04:C9:C0:9A:8B:CE:D4:37:4D:96:0E:74:FE:90
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication
+            X509v3 Key Usage:
+                Digital Signature, Key Encipherment
+            X509v3 Subject Alternative Name:
+                DNS:server
+    Signature Algorithm: sha256WithRSAEncryption
+         72:b4:75:02:f7:7b:e9:07:c6:79:1b:bb:11:e4:73:4a:b4:76:
+         1c:03:b9:58:8c:0a:80:f0:c6:8c:cc:2a:a7:c7:8c:57:a8:6e:
+         52:19:f0:b5:7c:0f:06:ab:2f:04:0e:99:32:b9:2c:b6:42:f0:
+         f5:5b:97:32:ce:bb:0c:ee:9f:b0:0b:bc:0b:c0:43:1d:7d:04:
+         b4:a1:cf:a0:aa:fe:f1:cc:b4:31:b3:bb:78:ed:0e:60:8d:37:
+         ea:48:a7:b4:2d:6d:64:6e:97:15:aa:e4:9b:b4:68:79:c8:3b:
+         ba:91:0b:db:cd:04:a3:aa:e4:69:59:06:ec:50:68:6d:0d:a6:
+         38:32:55:76:09:10:00:da:ac:a8:9e:ad:ad:95:8f:01:88:c9:
+         40:af:9a:5c:2d:17:34:81:6b:26:65:8a:e5:2a:15:79:13:2d:
+         ae:d8:03:16:6b:e9:b6:cd:f3:cb:d5:4d:5f:40:76:7a:99:99:
+         d5:2f:e8:a1:59:88:01:6b:a1:36:c0:53:dc:46:07:fd:ab:ab:
+         2a:5b:d3:d5:4c:84:c2:fb:48:16:80:80:01:f6:37:80:3a:54:
+         81:11:24:86:a6:a2:9a:73:06:5f:ca:24:8c:20:3a:40:6e:95:
+         8e:44:46:ef:60:bc:9d:11:ad:71:af:61:85:a6:e2:b4:49:c7:
+         fa:bb:ef:b5:c9:02:d2:a2:a5:3b:f6:46:03:dc:58:9f:ff:dc:
+         23:6b:b5:02:4c:1a:1a:80:99:6d:1a:fd:24:fc:32:83:f7:de:
+         fd:2b:b2:45:b7:3b:89:3c:49:0c:3d:0b:05:67:a5:95:00:3d:
+         cd:a7:0a:3b:b5:cd:02:10:09:de:ff:6c:6b:8b:aa:9d:e6:e9:
+         07:83:e2:dd:de:6d:bc:9e:fd:19:77:30:5d:67:12:c2:33:40:
+         0f:13:69:98:02:ef:05:b2:ad:ef:fb:73:15:57:70:46:83:32:
+         a9:05:4d:31:06:3d:44:93:88:69:de:9a:67:b4:6b:b7:0d:6b:
+         69:24:8b:62:52:f7:85:66:8f:84:2d:c0:a7:ff:33:37:7c:f3:
+         d1:1f:8c:b6:16:a3:98:db:6e:aa:e5:eb:d8:ed:06:31:19:ba:
+         01:f1:e6:3e:bc:78:ec:6e:b4:af:6c:8a:49:0f:ff:5a:f0:00:
+         88:d8:66:af:d6:49:31:b5:54:ce:be:07:59:46:bb:67:73:4b:
+         b8:ec:be:16:04:ed:fe:75:57:21:d6:d5:7b:cc:d0:7c:bd:91:
+         d3:6e:61:72:04:30:24:45:0a:0d:16:b6:35:94:49:02:14:8d:
+         2d:1d:71:42:13:9a:02:1e:3c:31:05:b4:76:5b:dd:ff:bb:db:
+         f4:31:b7:47:bb:54:f8:27
+-----BEGIN CERTIFICATE-----
+MIIFYjCCA0qgAwIBAgIRAJeAxmu1hIGzK/ZWVdpnTcgwDQYJKoZIhvcNAQELBQAw
+EzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMjUxMDAyMTE0
+NTEyWjARMQ8wDQYDVQQDDAZzZXJ2ZXIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+ggIKAoICAQC+9+4VvLbhBCg+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzp
+dSdVJDn87pLR2t7iXwFQtq5SGnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV
+0SgttwhOoGT7xrTii2FoTnJyzNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWY
+nkg8BJfNozaSFRKkv0bqlTcMbwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2Lq
+onkBedBYqix/iRS8PobAXlisWMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8M
+ayXTzuE/6GhsMXrfiElto34iJAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17
+uiJkjrfBERHx4R+5PimxYZuKHC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZd
+xo20r4tMLwhNN8O/bWiZxPdHzF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7
+ncOwWZNRIKHYog/lYnYXs7uqvDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKr
+W4z1gP+0mKKHFXI4d3bc4tGsL2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT
+8cE9itGkEqZwFjeAT9l5YUUcB3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABo4Gy
+MIGvMAkGA1UdEwQCMAAwHQYDVR0OBBYEFEqRwj6h6QTJwJqLztQ3TZYOdP6QME4G
+A1UdIwRHMEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhD
+aGFuZ2VNZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwEwYDVR0lBAwwCgYIKwYBBQUH
+AwEwCwYDVR0PBAQDAgWgMBEGA1UdEQQKMAiCBnNlcnZlcjANBgkqhkiG9w0BAQsF
+AAOCAgEAcrR1Avd76QfGeRu7EeRzSrR2HAO5WIwKgPDGjMwqp8eMV6huUhnwtXwP
+BqsvBA6ZMrkstkLw9VuXMs67DO6fsAu8C8BDHX0EtKHPoKr+8cy0MbO7eO0OYI03
+6kintC1tZG6XFarkm7Roecg7upEL280Eo6rkaVkG7FBobQ2mODJVdgkQANqsqJ6t
+rZWPAYjJQK+aXC0XNIFrJmWK5SoVeRMtrtgDFmvpts3zy9VNX0B2epmZ1S/ooVmI
+AWuhNsBT3EYH/aurKlvT1UyEwvtIFoCAAfY3gDpUgREkhqaimnMGX8okjCA6QG6V
+jkRG72C8nRGtca9hhabitEnH+rvvtckC0qKlO/ZGA9xYn//cI2u1AkwaGoCZbRr9
+JPwyg/fe/SuyRbc7iTxJDD0LBWellQA9zacKO7XNAhAJ3v9sa4uqnebpB4Pi3d5t
+vJ79GXcwXWcSwjNADxNpmALvBbKt7/tzFVdwRoMyqQVNMQY9RJOIad6aZ7Rrtw1r
+aSSLYlL3hWaPhC3Ap/8zN3zz0R+MthajmNtuquXr2O0GMRm6AfHmPrx47G60r2yK
+SQ//WvAAiNhmr9ZJMbVUzr4HWUa7Z3NLuOy+FgTt/nVXIdbVe8zQfL2R025hcgQw
+JEUKDRa2NZRJAhSNLR1xQhOaAh48MQW0dlvd/7vb9DG3R7tU+Cc=
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQC+9+4VvLbhBCg+
+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzpdSdVJDn87pLR2t7iXwFQtq5S
+GnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV0SgttwhOoGT7xrTii2FoTnJy
+zNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWYnkg8BJfNozaSFRKkv0bqlTcM
+bwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2LqonkBedBYqix/iRS8PobAXlis
+WMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8MayXTzuE/6GhsMXrfiElto34i
+JAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17uiJkjrfBERHx4R+5PimxYZuK
+HC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZdxo20r4tMLwhNN8O/bWiZxPdH
+zF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7ncOwWZNRIKHYog/lYnYXs7uq
+vDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKrW4z1gP+0mKKHFXI4d3bc4tGs
+L2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT8cE9itGkEqZwFjeAT9l5YUUc
+B3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABAoICAAnfT1OYWevwBxSQXg+JJZ2U
+BRAls9RZ4eSvBSqA+ITD0oJKgM+B15nKEKp6IPVOcBChO/x/5NWDXCeqbrR8rgIs
+3EnCtT/NYsxhS5fgw3ONUfnQa8Gvg+bw1R7n42oNKKtLbnZ3tiVqSMhehr78bi7V
+vNIUEnp2oMbbtXzPo5GxlT/TkyalEd698AYKRr6+vUd4B2q06Lmf1SSzaNNZJVFP
++mj5aJ/+h1up3iUh1gOBGM7gkavEZiyzEYZeAcNTqNE/CO9iXBz9w5/FRs+UuzBz
+29P//tDTyciMCX/8EcL0WhxVX5HR91dxApecjlB7d0qAlFWR+hnM5exl6HcqfC3C
++Uhi5IC+gZjD2KCcHDr9e5WqQ6cu8TeMnoyuHInIV9kUL3Bn1ArOU1dmGS78soeE
+GpqGCRc9Imh8jxs1AVyj9wGzpfuRS8OBpfR5MIlcFwSlZO/6dnJSaF2BH1jnKgBG
+Xn9MvjfHTU/EhLTteXrAJlqQr4e/uAK5QCESFNXLvC0r3qord6b9Y0zHR63SpESJ
+WVUIF9L2fIh0Z4CutPegcbEyWLaaAT4njyR4uCI78g77kK+PGi2NM65Mk+wKt975
+m3Qh4/cNv1ews4h+RflayWC9kiiRVzDHJGTy63k5gdplqrW2rb8gK3ZQaT2gQp9u
+gjKIIFGyi+EIDSukHNdRAoIBAQDuGvE9k1lSvoPgSusogMk7PWTiZbn8MwlEFueM
+ZJk9k8dMSkqF1k5BXG9lHcWuFl2invgTiFJIF7ML0GDsFJR+CzCDsanSGdjyKfGM
+HzHAc7UPAJYBXPX1rxTAhGSirKjArcqYUX3ZGGaTo1yZrsbbarInUhWWNKFBdaQ+
++L3oClGt3GZx7hdxapI/3gnkLvG/C5hWWetLONZAxY6jwJJSA/p2Fx93SlWOtrmT
+KRbM/p8m6sHtsXcBnYTueqWYpJ2mnBIB+Svf5acqQ2Xf8kAIw4Vw9u7a15OlIDGF
+ouWhtSkL4s0YfZjlXswOPZDlF3eT2ilf+OIjv5kEcLdDKOojAoIBAQDNUhfys2TH
+b1NFsIH6X1jtWHUEGOYIM/y/75Vw2pGLb40cMxVPtzsNCvz8id/sCuvx6yUWlBlN
+wjpa+7dOA+FgoXwv1iVsQm1zQlrt2VKaEy29C0tRkSwOjNC0bz1409wzYNnh5Bdx
+KJDvSz9zlefAryJGTSgGOothOjnguzoEJ6DxfkxNyWbxceBgN8JljDhc9dcybKdD
+Uxy2GflXhZvZfCtTbYfWoIV+dTYyZt2QE4PEPXrJHGUFE9ncGynbzAn1Cc/zGBeT
+zFNoYOCWNr7ueRNHQYMRZ1N3dYRdZ9th5mdqqa1eY5lP4PyQYZV6lwmyEfitXwNz
+vhS0sO+pNAyXAoIBAB9OiZOoESGRDTPrhdnwfQT+AIrIB1lCuKAsRsut2nw/NwAv
+8HaChA2SAs+Px5MpO6yLLGEdFnyGKTOPdX71AcVE4V8feA24+k50916OJ3N/gzny
+wMZzG5/vIlJh1f2RqCqVb0LxzBNEYxBcdWt7kIf/EmebIl16lA1QU4U4HXgqCy1K
+AmpOfOSbt5kQL8rB5WVSN/h6oDZmxb0EfMnJIzQHc+IdDjUYIAHAwsu3pljTzcdH
+LLJ9GAGtXXIhzC4yzsu+T5vU0FEDGCS1ceqtJoBAfQYqYaOCntYiUoCYt4q4kCoQ
+6xiiQv09pqTksW191WoqUDBfQBSlN5Be5am98nMCggEAIzEb+7R15J0XN82uKZzo
+IB5WSDKAUw2eF8PX6HT+F1kyZY/36ibszyp//EUhhVLF6Dw2qi0OPT66Q9f7LjsK
+CUcEgyqAVZL5MZVBAp2KQ/BfmZRy/3MTixbluteKQMiHaKMEFWzD+9hJJ0rNgGFE
+TMl35XbaEl88fpi9TOCqbAXi1yGfsIGBzIaJP9Su1Dr5ei2FChaHgMmhFTFUhITZ
+FqjqwCz46HexCeDLPk5VUZmWry8eeZQNWJZzc/+P6CWL210oMHGDsQiHj09zjyup
+BDTqcf8vmO8N5l7VJjFj797PAQA+P/xwTbmxcInZVh7HQadE6WpsrAz7fZEKMwVB
+1wKCAQEA3oqXI9bGGoXFjydUiNMZbuHdIDQCa9t7iDb+J+NAiA7GI8W8DlFYrUST
+S/CoBey/WOW9jPT/A8EBnp8RmPtAJH88qklbqh/YCoKyKZrgqT5IGysRLWwDFrGT
+QoOvR1a6SaVMLskmYUCkl8Yz8sZS58X50ahxx5TB0I3xsoCmnMZt+cd2C/VXwhFz
+jCiEZIuQlSgQFW4LOFrxrXmI+MDOBWu4zvkztWOnTe+BNgrxndGVI6sdFGzWeNQx
+dQ9imn0UqGSkgnJEj7Lq67ey8Cuu6yYWexKI0N9UOcyL4FgaEdWiJ0t5KY6NElGI
+0jrZX7pwVf/pvbKW2zVm6nXjWJ/JFw==
+-----END PRIVATE KEY-----
+</key>
+<dh>
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEAqJI9Luwkfy0E95gqZyq031Fa1rUCW5aBoppgm4YHxGUL+fUQzveF
+U2+W5xzmZuxhyoN0PVqlPXoMi0xGyTW4ga8qMaIHDqQ/V8RNxQYJ+GEEiC46/2u9
+Co/HbGX9YXMm5nnNEtHepAHcJiRB6QbCjzVm06x5QfWifj/yTm9ycVfJXhQJiOkD
+j4y4vJbgrmIKWX8Nxj4Q8dCAJzZ2gFvMnW9XcbS9SYbyvS0DvoQG3gPTGcopv7x1
+NiOhrxcTcMjwi/2z6kxG0MJEZ1HOJ2xTtRReUGXkL0lhbVTzkX4V6ihWK4MZYqe+
+ozy/0gbPAB4dT1QNeSRXPOi9f81Oed0SoC83P0oiq3JRQq2g7aS9OiwqlRPnVnvH
+q7Uko6+nv8XLbANgbdLXc8I3K78TSedwofxI/atxKncEic0fHV5ai2IdEWt22qxj
+iWVyaiHlWtMosZvuepSPn3cAmfuj0dVPNiRoG97neN8XIOaVZNGmNnI4yM0JEA1h
+Ef4Lh4YpDdqk4Q/nC/zJev8PM1XC+Os1SsGH50YAn8q19TGzI26/Y4jWfqrHswsj
+6vF/lxDS5RRzLIqlEksm84MU1q0AFSe9FaW1NTtKR/PLO1QiSKr718BwzzrDNN9u
+KZJabQ9n1RgLSuMP9zk9A6GUPQ7cZ0fJchUPeuF8Cd7zAV7k4m0RA4MCAQI=
+-----END DH PARAMETERS-----
+</dh>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.6.5-alpine-3.18/Dockerfile
+++ b/variants/2.6.5-alpine-3.18/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.18
+
+RUN apk add --no-cache openvpn~=2.6.5 iptables
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/2.6.5-alpine-3.18/docker-compose.yml
+++ b/variants/2.6.5-alpine-3.18/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '2.1'
+services:
+  openvpn-server:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/server.conf
+      - NAT_MASQUERADE=1
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/server.conf:/etc/openvpn/server.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    ports:
+      - 1194:1194/udp
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped
+
+  openvpn-client:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      - OPENVPN_CONFIG_FILE=/etc/openvpn/client.conf
+      - NAT_MASQUERADE=0
+      # - CUSTOM_FIREWALL_SCRIPT=/etc/openvpn/firewall.sh
+    volumes:
+      - ./openvpn/client.conf:/etc/openvpn/client.conf
+      # - ./openvpn/firewall.sh:/etc/openvpn/firewall.sh
+    cap_add:
+      - NET_ADMIN
+    # sysctls for the container if it is not set on the host. See: https://docs.docker.com/compose/compose-file/compose-file-v2/#sysctls
+    sysctls:
+      - net.ipv4.conf.all.forwarding=1
+      # - net.ipv6.conf.all.disable_ipv6=0
+      # - net.ipv6.conf.default.forwarding=1
+      # - net.ipv6.conf.all.forwarding=1
+    restart: unless-stopped

--- a/variants/2.6.5-alpine-3.18/docker-entrypoint.sh
+++ b/variants/2.6.5-alpine-3.18/docker-entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+# Env vars
+OPENVPN_CONFIG_FILE=${OPENVPN_CONFIG_FILE:-/etc/openvpn/server.conf}
+OPENVPN_SERVER_CONFIG_FILE=${OPENVPN_SERVER_CONFIG_FILE:-} # Deprecated. For backward compatibility
+OPENVPN_ROUTES=${OPENVPN_ROUTES:-}
+NAT=${NAT:-1}
+NAT_INTERFACE=${NAT_INTERFACE:-eth0}
+NAT_MASQUERADE=${NAT_MASQUERADE:-1}
+CUSTOM_FIREWALL_SCRIPT=${CUSTOM_FIREWALL_SCRIPT:-/etc/openvpn/firewall.sh}
+
+# Normalization
+if [ -n "$OPENVPN_SERVER_CONFIG_FILE" ]; then
+    echo "Warning: OPENVPN_SERVER_CONFIG_FILE is deprecated. Use OPENVPN_CONFIG_FILE instead."
+    OPENVPN_CONFIG_FILE="$OPENVPN_SERVER_CONFIG_FILE"
+fi
+
+# If no args are passed, run the entrypoint. If a flag is passed, run openvpn directly. Else, run the passed command
+if [ "$#" -eq 0 ]; then
+    # Provision
+    echo "Provisioning tun device"
+    mkdir -p /dev/net
+    if [ ! -c /dev/net/tun ]; then
+        mknod /dev/net/tun c 10 200
+    fi
+    if [ -f "$CUSTOM_FIREWALL_SCRIPT" ]; then
+        echo "Executing custom firewall script: $CUSTOM_FIREWALL_SCRIPT"
+        . "$CUSTOM_FIREWALL_SCRIPT"
+    else
+        echo "Not executing custom firewall script $CUSTOM_FIREWALL_SCRIPT because it does not exist"
+    fi
+    if [ "$NAT" = 1 ]; then
+        echo "NAT is enabled"
+        echo "Provisioning NAT iptables rules"
+        echo "NAT_INTERFACE: $NAT_INTERFACE"
+        if [ "$NAT_MASQUERADE" = 1 ]; then
+            echo "NAT_MASQUERADE is enabled"
+            iptables -t nat -C POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -o "$NAT_INTERFACE" -j MASQUERADE
+            if [ -n "$OPENVPN_ROUTES" ]; then
+                echo "Provisioning NAT iptables rules for OPENVPN_ROUTES=$OPENVPN_ROUTES"
+                for r in $OPENVPN_ROUTES; do
+                    iptables -t nat -C POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE > dev/null 2>&1 || iptables -t nat -A POSTROUTING -s "$r" -o "$NAT_INTERFACE" -j MASQUERADE
+                done
+            else
+                echo "Not provisioning route iptables rules because OPENVPN_ROUTES is empty"
+            fi
+        else
+            echo "Not provisioning NAT iptables rules because NAT_MASQUERADE is disabled."
+        fi
+    else
+        echo "NAT is disabled."
+        echo "Not adding NAT iptables rules"
+    fi
+
+    echo "Listing iptables rules:"
+    iptables -L -nv
+    echo "Listing iptables NAT rules:"
+    iptables -L -nv -t nat
+
+    # Generate the command line. openvpn man: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
+    set openvpn --cd /etc/openvpn --config "$OPENVPN_CONFIG_FILE"
+    echo "openvpn command line: $@"
+    exec "$@"
+elif [ "$#" -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    echo "openvpn command line: $@"
+    exec openvpn "$@"
+fi
+
+exec "$@"

--- a/variants/2.6.5-alpine-3.18/openvpn/client.conf
+++ b/variants/2.6.5-alpine-3.18/openvpn/client.conf
@@ -1,0 +1,258 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/client.conf
+client
+dev tun
+proto udp
+remote openvpn-server 1194
+remote-random
+# Push all traffic into the tunnel
+;redirect-gateway def1 bypass-dhcp
+resolv-retry infinite
+nobind
+user nobody
+group nobody
+persist-key
+persist-tun
+remote-cert-tls server
+cipher AES-256-CBC
+auth SHA512
+comp-lzo
+verb 4
+key-direction 1
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:4e:3e:ee:0c:a0:be:17:77:36:7e:3e:48:bf:5a:f3
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=client-01
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:b3:ef:25:0f:86:77:8e:9f:a4:42:02:f0:19:0e:
+                    20:0e:93:5e:67:78:17:99:a9:cd:06:84:fe:c1:ed:
+                    5b:c9:96:d1:82:ef:5f:a5:95:d7:de:99:97:84:cc:
+                    a8:28:13:69:2f:41:7a:d4:f0:ac:a7:a3:10:8a:31:
+                    c6:aa:14:dd:d0:5d:15:51:2c:e9:5e:3e:fe:f0:1c:
+                    d7:62:07:f7:fb:01:93:22:8f:4b:72:77:76:8a:14:
+                    fe:26:52:59:c8:59:b0:01:b6:cb:7a:2d:ba:0d:35:
+                    a2:8c:42:97:18:54:45:58:f1:69:ff:3b:ce:fd:71:
+                    a5:13:42:82:ca:e2:25:43:61:d6:34:1f:f6:f3:36:
+                    7f:c9:7d:a4:e2:83:f1:8f:b7:2d:cd:7f:cf:1a:90:
+                    a4:86:ce:c0:6b:36:b3:9e:90:d0:60:5c:ec:ac:70:
+                    f7:32:16:59:20:1f:27:a5:3c:00:a0:9b:63:30:41:
+                    a5:d3:63:37:9d:10:f7:f6:53:45:54:57:70:7e:06:
+                    a6:01:32:38:2c:2d:d1:11:4c:3f:57:25:5a:2c:2c:
+                    06:a0:20:bb:c0:95:fd:44:a8:0d:3a:b0:c9:a3:b2:
+                    77:ce:f7:f0:f5:c8:1c:a7:74:ba:b9:83:0b:3c:56:
+                    6f:18:cb:df:39:77:3a:69:18:57:be:48:7e:ab:2a:
+                    21:2d:b0:eb:4c:26:ae:93:f2:d9:0d:29:01:b8:2c:
+                    0b:5a:ec:8a:c0:fd:5d:1c:a7:6f:31:29:5d:5c:35:
+                    cd:0e:e0:97:86:07:af:5e:69:8e:e7:e1:f0:78:21:
+                    f3:15:c6:35:cd:e6:4b:65:d5:17:0b:87:6e:ea:39:
+                    44:96:ab:bc:fc:ee:27:85:fe:10:c4:77:96:25:cd:
+                    9a:66:ee:e4:36:fb:f0:c8:90:62:de:6d:f6:8c:19:
+                    76:c6:6d:c3:9c:a4:9f:80:ec:39:79:ba:32:36:b2:
+                    7d:93:3c:dc:58:c5:13:34:35:8a:7e:cb:cc:f0:9a:
+                    bb:39:dd:ca:bc:cf:c7:7a:8f:9b:60:f1:a8:e6:e4:
+                    41:62:82:cd:cc:d2:81:06:c1:5b:82:0c:49:88:e6:
+                    bd:39:b2:06:82:a0:fb:55:ba:fd:de:57:2f:40:84:
+                    07:b8:38:9a:49:6e:38:49:c0:b9:26:f7:7e:a9:9a:
+                    18:b3:27:b9:d9:b3:fb:7f:6d:9e:68:58:94:f7:b1:
+                    21:b5:ee:59:b0:7f:fc:0f:ab:00:c2:8e:94:34:09:
+                    c3:45:dd:4c:79:03:b8:bf:ce:55:8f:6e:6d:c9:ff:
+                    4c:5b:da:fb:eb:70:bd:c9:37:68:6e:03:e0:db:2f:
+                    6e:db:6c:d4:f0:1f:01:43:42:6e:f6:31:4b:8d:fb:
+                    21:1e:77
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                23:46:34:1C:74:3B:D8:21:40:4D:81:B3:58:9F:57:CB:0C:5E:90:FB
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+    Signature Algorithm: sha256WithRSAEncryption
+         3c:80:ef:a8:a1:94:bc:12:33:6c:19:2e:44:44:6c:20:8e:69:
+         f6:b8:21:ad:4b:f7:14:d6:bf:c3:8d:b0:87:d1:e2:55:df:c0:
+         fd:03:31:82:8a:82:dd:68:3d:61:1f:c4:89:eb:e6:07:b0:89:
+         1d:19:8b:ee:57:9f:87:d8:a2:d8:fe:84:ad:f1:18:9c:b5:93:
+         a1:17:48:41:1e:f7:12:1e:50:46:b7:57:93:6e:d5:0f:d5:84:
+         a8:8e:74:4f:ab:8a:ae:40:64:8a:a8:57:32:75:b6:82:20:10:
+         be:ab:70:0c:96:c7:30:f4:69:c7:c9:24:db:3a:bc:40:eb:ac:
+         ee:04:f3:58:4a:09:6e:42:01:b4:a5:77:e5:2b:01:05:c1:5c:
+         08:59:0b:e3:a9:7a:b4:3e:f9:41:8d:2b:e6:8e:40:27:07:07:
+         0d:b0:03:ba:c9:d2:cd:dd:3c:9a:7e:20:66:bb:7f:4f:9d:fc:
+         37:16:88:84:a1:26:6a:91:43:d1:47:82:cb:e1:84:d4:03:93:
+         ec:8d:14:ce:2c:c8:fc:96:f8:28:d5:cb:89:c8:84:ee:8a:54:
+         8e:3c:12:86:10:73:78:5c:b8:a5:7d:99:94:b1:e1:f9:18:ed:
+         4b:2f:ae:8d:d4:9b:bc:20:21:d3:13:ed:07:15:70:dc:d1:1f:
+         58:22:fc:0e:5a:49:4e:6f:c1:99:9d:de:71:4e:62:7d:ad:d3:
+         2e:c3:ca:3f:db:cf:f3:46:aa:95:1f:99:1c:81:f8:15:5a:a1:
+         30:f7:7b:4a:e1:8a:fa:8b:a4:92:6d:11:e3:4c:f5:2b:b9:a3:
+         6d:a4:07:93:cb:28:f7:06:c1:e8:1b:1e:c5:aa:76:51:7e:1b:
+         a7:fe:db:9b:d4:23:d1:2a:16:52:ed:d1:2c:55:2b:cd:db:73:
+         fa:20:1a:18:47:af:90:50:0c:fe:1b:0d:f6:06:ec:33:1f:8e:
+         6f:f2:9a:d0:49:88:cb:a0:8c:8a:60:54:8e:d0:c1:59:ad:e6:
+         6e:6a:3e:e4:3b:b4:1b:01:8e:81:a4:f2:21:94:d1:a7:5e:e8:
+         1a:14:af:f1:46:5d:6a:ad:9d:06:02:84:58:96:b2:e6:f8:02:
+         5f:ce:ed:87:54:b5:f9:b6:62:97:51:b2:88:05:49:de:fd:56:
+         d1:67:e5:59:78:31:82:36:17:ce:07:62:81:5c:19:82:48:22:
+         88:15:ea:d9:fc:1e:c3:ee:05:a5:ec:e9:ca:69:b5:2a:7e:79:
+         ed:aa:6e:3f:b5:45:75:0b:d4:27:e4:4c:88:04:e0:06:36:5e:
+         41:37:b0:f5:44:80:58:86:dc:c1:be:82:62:fe:a8:2c:6c:ca:
+         6a:f8:dd:fd:85:df:5a:41
+-----BEGIN CERTIFICATE-----
+MIIFUTCCAzmgAwIBAgIQDU4+7gygvhd3Nn4+SL9a8zANBgkqhkiG9w0BAQsFADAT
+MREwDwYDVQQDDAhDaGFuZ2VNZTAeFw0yMzA2MzAxMTQ1MTJaFw0yNTEwMDIxMTQ1
+MTJaMBQxEjAQBgNVBAMMCWNsaWVudC0wMTCCAiIwDQYJKoZIhvcNAQEBBQADggIP
+ADCCAgoCggIBALPvJQ+Gd46fpEIC8BkOIA6TXmd4F5mpzQaE/sHtW8mW0YLvX6WV
+196Zl4TMqCgTaS9BetTwrKejEIoxxqoU3dBdFVEs6V4+/vAc12IH9/sBkyKPS3J3
+dooU/iZSWchZsAG2y3otug01ooxClxhURVjxaf87zv1xpRNCgsriJUNh1jQf9vM2
+f8l9pOKD8Y+3Lc1/zxqQpIbOwGs2s56Q0GBc7Kxw9zIWWSAfJ6U8AKCbYzBBpdNj
+N50Q9/ZTRVRXcH4GpgEyOCwt0RFMP1clWiwsBqAgu8CV/USoDTqwyaOyd8738PXI
+HKd0urmDCzxWbxjL3zl3OmkYV75IfqsqIS2w60wmrpPy2Q0pAbgsC1rsisD9XRyn
+bzEpXVw1zQ7gl4YHr15pjufh8Hgh8xXGNc3mS2XVFwuHbuo5RJarvPzuJ4X+EMR3
+liXNmmbu5Db78MiQYt5t9owZdsZtw5ykn4DsOXm6MjayfZM83FjFEzQ1in7LzPCa
+uzndyrzPx3qPm2DxqObkQWKCzczSgQbBW4IMSYjmvTmyBoKg+1W6/d5XL0CEB7g4
+mkluOEnAuSb3fqmaGLMnudmz+39tnmhYlPexIbXuWbB//A+rAMKOlDQJw0XdTHkD
+uL/OVY9ubcn/TFva++twvck3aG4D4Nsvbtts1PAfAUNCbvYxS437IR53AgMBAAGj
+gZ8wgZwwCQYDVR0TBAIwADAdBgNVHQ4EFgQUI0Y0HHQ72CFATYGzWJ9XywxekPsw
+TgYDVR0jBEcwRYAUmBuw7bvaYZi1OnrIxE4ycKX4qQehF6QVMBMxETAPBgNVBAMM
+CENoYW5nZU1lghQRFLv/ZzUIweAY3+3bxHLwDm1FLDATBgNVHSUEDDAKBggrBgEF
+BQcDAjALBgNVHQ8EBAMCB4AwDQYJKoZIhvcNAQELBQADggIBADyA76ihlLwSM2wZ
+LkREbCCOafa4Ia1L9xTWv8ONsIfR4lXfwP0DMYKKgt1oPWEfxInr5gewiR0Zi+5X
+n4fYotj+hK3xGJy1k6EXSEEe9xIeUEa3V5Nu1Q/VhKiOdE+riq5AZIqoVzJ1toIg
+EL6rcAyWxzD0acfJJNs6vEDrrO4E81hKCW5CAbSld+UrAQXBXAhZC+OperQ++UGN
+K+aOQCcHBw2wA7rJ0s3dPJp+IGa7f0+d/DcWiIShJmqRQ9FHgsvhhNQDk+yNFM4s
+yPyW+CjVy4nIhO6KVI48EoYQc3hcuKV9mZSx4fkY7Usvro3Um7wgIdMT7QcVcNzR
+H1gi/A5aSU5vwZmd3nFOYn2t0y7Dyj/bz/NGqpUfmRyB+BVaoTD3e0rhivqLpJJt
+EeNM9Su5o22kB5PLKPcGwegbHsWqdlF+G6f+25vUI9EqFlLt0SxVK83bc/ogGhhH
+r5BQDP4bDfYG7DMfjm/ymtBJiMugjIpgVI7QwVmt5m5qPuQ7tBsBjoGk8iGU0ade
+6BoUr/FGXWqtnQYChFiWsub4Al/O7YdUtfm2YpdRsogFSd79VtFn5Vl4MYI2F84H
+YoFcGYJIIogV6tn8HsPuBaXs6cpptSp+ee2qbj+1RXUL1CfkTIgE4AY2XkE3sPVE
+gFiG3MG+gmL+qCxsymr43f2F31pB
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQCz7yUPhneOn6RC
+AvAZDiAOk15neBeZqc0GhP7B7VvJltGC71+lldfemZeEzKgoE2kvQXrU8KynoxCK
+McaqFN3QXRVRLOlePv7wHNdiB/f7AZMij0tyd3aKFP4mUlnIWbABtst6LboNNaKM
+QpcYVEVY8Wn/O879caUTQoLK4iVDYdY0H/bzNn/JfaTig/GPty3Nf88akKSGzsBr
+NrOekNBgXOyscPcyFlkgHyelPACgm2MwQaXTYzedEPf2U0VUV3B+BqYBMjgsLdER
+TD9XJVosLAagILvAlf1EqA06sMmjsnfO9/D1yByndLq5gws8Vm8Yy985dzppGFe+
+SH6rKiEtsOtMJq6T8tkNKQG4LAta7IrA/V0cp28xKV1cNc0O4JeGB69eaY7n4fB4
+IfMVxjXN5ktl1RcLh27qOUSWq7z87ieF/hDEd5YlzZpm7uQ2+/DIkGLebfaMGXbG
+bcOcpJ+A7Dl5ujI2sn2TPNxYxRM0NYp+y8zwmrs53cq8z8d6j5tg8ajm5EFigs3M
+0oEGwVuCDEmI5r05sgaCoPtVuv3eVy9AhAe4OJpJbjhJwLkm936pmhizJ7nZs/t/
+bZ5oWJT3sSG17lmwf/wPqwDCjpQ0CcNF3Ux5A7i/zlWPbm3J/0xb2vvrcL3JN2hu
+A+DbL27bbNTwHwFDQm72MUuN+yEedwIDAQABAoICAAuYKlwwvv16vfve8pe6uEgY
+KOoj6+lj7qkv4raeU97OkBuOzyv9VtaqMQBGq8NBVPLNlluoUofO0x8EjBejlpN5
+nAkKCtOe3ZCdWyee+dS7yj5c23C5z/Kf3ayce9qUJOpHXB84WRfGz/2XwOK5c2qC
+y+C9et4L96YhEAqAvgP0hvf+40vSxDM4nGpYNDWdiR8H0FGW5nMlWXLPKI3cKQE8
+m6eU8+jPVdjjCQv1rNisipyubkAL0aaWVFQUE5CWvdHxHbtQABygqyshLaew6XmV
+MKwaz95eC97jsU6J28RnmJ7GjUlZJreHpwyTLCMsMqZ3ZJ/wVdw1zFmflEH1SgPq
+/JNd0OONKm8x7nORX9dHEn33Imfyg2jI6tzVx1oAmMWMb9hJ0XjkIyzjfHTPi5KW
+pM3pTUUn6ee4P1T4ReBlatiw2TFgAd18/9gSIaSlENEjslJGQ6/Ndt9O7UNHgwth
+ZNtPovjNLqUobHGXlmwg3haeBshn9iPcjdksAjgtjEyowzq7IpiSxQezXNcMezGM
+Y9UL5Qc/yjQ3t+Vu94Jmnu0TT3lHGWa3zSgI6L+UdBiIsLF6P5YQVloYOYWE3q/n
+HTaORoZlsRKfMIUHmhrZ1keJ4VGqLruSpQHobh3Cfb/xzgOEB3nSwhIK3l2FhSiR
+N9jb0r7kMElO+xlm7NChAoIBAQDllnlfyWnTBGog8+T9eJiODuBfdozy2vCZO8nc
+vp11NC7fLh5NXR16Ju6I+dcXDhPdoOG8H/DScjer82kEINrY7Wb4swNd01cLCg+/
+xVNe9iiLl4Q4m/QOI6ZOUbOfJjH9R8J4Bh/FzR1MXtVktgtsd6JB3zv6V246zDjy
+eMnOImwoj6TH/3hI/g2s5i3GoaC7CK+XjpdfZbVAX5+mnpZxBbOqXt7an1IzYHhx
+hQO8uo/9b2IDxMrWWn80mGj9Fw5AdK1Ef3eMtbyG6iOIR92UEo9ZwlZ9Tang58Sa
+7IFHZko/HcCrS92Hl9YcnYmjG0GDeFl4des+IcVz0AHDhe6RAoIBAQDIolXgCYO3
+zo2MtoBTCr+GcluT4DD16ALz7wd8/jXFqmD3UWCAeaS5IsTno1PmuIpvB7dvwz8B
+6SOpE//J/bECDmhE18UHYOAqkXzzuuEGMCP1TuaCWBq7kWV8GVTRcSGQDxLyf/Yu
+IdxiPQMaCxi0Ffv+aq27Nii1IyV8tyDL3skyGZeQJNW2xjNkngkXsB5Tp7H7tA0G
+lSmld1Rtq2XWcRnHQh9ZVP+FxwkjBkdoX0oAASVQwHsy9Q4hZ5ykxPkIGULj3Hw5
+zvG1RAM5B4GQegK0OfYuX5Ullrz6a/6p/FnGLvRkZGlHML/bHTmrr8ywSvF63Gkd
+oU0nqjPFQ1CHAoIBACoFR4PDno3TwgTz/tZxqyJdEK4ISbXtYpn5OnIfpTwdZ/LL
+QxqPz2RbGc+SQs7icbpfxtEi23X5F71uGKt7w/JuSSl9wkD6/HR1y/oiiKbZ0QPz
+oGyoBpxL5BVzmLepSv77kllbbZdLenBO7ym2tBKPNvBthlHEjNVQKaAfgXgsDrXB
+zLwaQw7BCQm7O2eej4eMCG9p1sTMHceBePwLDKf1DjRBlvJWtLnYj1LfsJZrYw1U
+xJDCBQoEmEGtH5IrFR2w/UGLPvtPDAl5czVvSdvfJcOc8S2P+GbEpNRiMys5Sp+Q
+t4HiqdI2dSbZoqZqx6vjbCTDGGJP1g7jZF8/9TECggEAXOXVj2O4an4oSnQiXNEI
+N29x+bl/0gy4eUw/El/+c+Tc+wbiAPrSC6sOsxaL/bOK3bgb9pLX9MGHcn1BHbzq
+ncIgA2hI4Y64nN06lvv7v0rBC4+Z6dZzok/DRr/P5x5T5Qklw8T+LwQcsBwB+KgU
+qyXWxUmN4bZFCQIaFHISrHMeg6UX6XU0w2loWHlYSnCQyjlGjv4iXd7pJqVnIVSQ
+VceOoRV7wHg7zCyJjX8Vxzz/3ZqqNYa6RLD09wCrphtSF67iqvDnUDkC7+Rq/Zf9
+JPFpmRuRYo19WKdAH0+r3fdrdfk9zdI0cPMgkosordc7lpFM2I9/2GlceTY0vGzb
+twKCAQEArUbkiwUZFjdjAbKS2m0uPJyytB8bZ335szcoMUV665hzU9EJPcWeVY0L
+1FSRu/cig+ZCmpUEc/4JhJVKLEEXgC3BgfHGNHi5PIuvssMT/fJJ9InQe8n4Zq0Q
+eZbrfAewrdH3bTpEf6AxIsrMioLsUQSV12iRQ7olsEP9t5HqRKqwhAnqp+q33XT3
+L++8IcaaEQ3S/sBb23pY+VSWQfKGFVQES+P7yKeNHjBNQpJTPOdM9iLtvriUmNdO
+Gy5HOpLgd10DzXBOI7CgqzFm69Bqk+WFZXGVd9T/Ku69B8XfshoRChGbgHbbEG70
+0xT4AQEuygYVBbUrIerZFpDD+Tw7ww==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/variants/2.6.5-alpine-3.18/openvpn/firewall.sh
+++ b/variants/2.6.5-alpine-3.18/openvpn/firewall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# This iptables script to controlling traffic in the openvpn tunnel.
+# In this example, clients can only perform DNS, HTTP and HTTPS requests to the world.
+
+# Drop everything by default from tunnel to world
+iptables -P FORWARD DROP
+# Allow DNS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p udp -m udp --dport 53 -m conntrack --ctstate NEW -j ACCEPT
+# Allow HTTP and HTTPS from tunnel to world
+iptables -A FORWARD -i tun+ -o "$NAT_INTERFACE" -p tcp -m tcp -m conntrack --ctstate NEW -m multiport --dports 80,443 -j ACCEPT

--- a/variants/2.6.5-alpine-3.18/openvpn/server.conf
+++ b/variants/2.6.5-alpine-3.18/openvpn/server.conf
@@ -1,0 +1,280 @@
+# See sample config file: https://github.com/OpenVPN/openvpn/blob/v2.4.8/sample/sample-config-files/server.conf
+port 1194
+proto udp
+dev tun
+server 10.8.0.0 255.255.255.0
+ifconfig-pool-persist tun-ipp.txt
+;client-config-dir ccd
+keepalive 10 120
+comp-lzo no
+max-clients 5
+user nobody
+group nogroup
+persist-key
+persist-tun
+status tun.status
+status-version 3
+;log-append server.log
+verb 4
+mute 20
+;duplicate-cn
+tls-version-min 1.2
+cipher AES-256-CBC
+auth SHA512
+key-direction 0
+;crl-verify crl.pem
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFQjCCAyqgAwIBAgIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMzMwNjI3
+MTE0NTEyWjATMREwDwYDVQQDDAhDaGFuZ2VNZTCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAMh7oK+Y4U4VN5lt3MEl2IlkofgZfjHI6fOzdZVdIcgNSkwm
+2P00zFW1+FR/eKzCq44TINum3EUiE2Z1UFEsEolgXwKd5zzkRRvryeQFAQppqXFU
+TOrQG4BCteDaKNnkdqVL7Zqp3xzWfhr8ygM+N1heBal88kvM38YKEVz2ZnEqd/Jk
+cptNijI8CWYYmCpscq6z7U7PDlIEFcstXb2KWGlgXKAtbW1hGw5HNFdALHMAHSv1
+ez0p+++neWR+7Ti1OntiaDYMTVoE+MVtCxHIBQ+sOEzfH82ukDkEglbPhPRVSilM
+FAYGSN36LxjqhLtwOSjt2UlAW0XHSiU61/qE8gB7yc6b+HHtcV7fe9HNQt0LkNh2
+7vD53oaXawn4//3eD+l3nnfIp6TlaGFkYAt6RJ1I36A2kjoaV29tk27YLCHhHwj4
+o4LMmg23fXW6ecyLnCWDHF9W1E8OZhLqPQ/Fgofhr8BOIRh6LMNdn72Ao0bE/XdD
+w2dtMASboSadHJsB7vtd+v/U0q6c4iIKR/c23nd4ZRAH4mv1Bs57OXKpviZ+rmO+
+13uUgBIrHUloO7yprwysF8UDDf6TkzG38yql9DIHcFU6uADRs6V63nRxyTvxiwZs
+Hz/rnTgkAxT29b8myhCW/TpaqI75i5DH5yjSRBunTV/UkYi4KEb0Nl7AU85RAgMB
+AAGjgY0wgYowHQYDVR0OBBYEFJgbsO272mGYtTp6yMROMnCl+KkHME4GA1UdIwRH
+MEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhDaGFuZ2VN
+ZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMC
+AQYwDQYJKoZIhvcNAQELBQADggIBAAbbhy74imUoD+MDYE2oREDMCJ4oRsOa3kTs
+5Ayqx4r3292ZmyIHHweOUyIJSC+BW9hCosqnl0uJxGoQ2358TaMFw7TrOpQjZIs1
+ycUZUHp/fg2TeVhN32M7z3xa6zhdmxK4+W19/cHPF4LlJqk45Odxza/R0IkWzTo9
+De7Kj/cYwP+ADEFOIrQxro5CfKqZcyLQCFsbh3MDNdvqt3cxmTR0Qo+GwLs+wLbG
+8Kgxc0qJ/MAaazOng0iyRz6uz+s72fqb3Qh9ZG94Hdqoo4IxhbCzy7coKmmzEJ6w
+w3OIDJZOFy1gjEHqRQzxtg/xga48Lq2o/HEyqFz7NSqk3xRzgck0NMIw5Iq6HuU2
+T6ovarXKt79YcExI9T94YJqKs0+0hMZdD70IP12bESTVtGJLkJCdj+hAkEfZiBhp
+X3bRStslNrMO/fc2c10kvtRgxcbuZryMgakCrfFq4CCOsUBmXq/IvmTbN71Zx/AD
+UQ1g2Y5zsOMlc4AOGBWXNyaKNh7B/u0/aAqAZwXJtqlIUmYqcCn4SQBmaGsba97B
+t7bInqFaKr63qlvS+jIYEwv882b4TrM9obBCE/uG8Iu7JjHizbp8/IZpRq9ZKXiJ
+J//FW4GtjxdCJPPe3ZNDoJTciIhFMSsUH4Le8E7FKPt1hgdhZ09yTqA1eqvCTB0Y
+OnkxZyxs
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            97:80:c6:6b:b5:84:81:b3:2b:f6:56:55:da:67:4d:c8
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=ChangeMe
+        Validity
+            Not Before: Jun 30 11:45:12 2023 GMT
+            Not After : Oct  2 11:45:12 2025 GMT
+        Subject: CN=server
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:be:f7:ee:15:bc:b6:e1:04:28:3e:38:6a:61:dd:
+                    ee:fa:61:85:9a:a7:be:44:22:52:b4:cf:7a:86:0e:
+                    21:ae:1e:2b:61:66:17:1f:54:dc:e9:75:27:55:24:
+                    39:fc:ee:92:d1:da:de:e2:5f:01:50:b6:ae:52:1a:
+                    79:6b:8d:56:0d:83:f6:d4:19:50:48:bc:cb:d8:69:
+                    c8:79:d4:ba:82:05:db:aa:58:12:4b:34:1b:15:d1:
+                    28:2d:b7:08:4e:a0:64:fb:c6:b4:e2:8b:61:68:4e:
+                    72:72:cc:da:a2:d8:cb:f5:6a:5d:13:b6:98:d3:0c:
+                    a3:05:7a:21:e3:f9:fb:de:89:be:37:ac:ce:4c:2e:
+                    95:98:9e:48:3c:04:97:cd:a3:36:92:15:12:a4:bf:
+                    46:ea:95:37:0c:6f:09:e1:51:f5:4e:13:9f:f5:68:
+                    65:0e:24:38:62:04:f8:f9:0c:06:72:c9:03:ed:5d:
+                    6f:40:3b:62:ea:a2:79:01:79:d0:58:aa:2c:7f:89:
+                    14:bc:3e:86:c0:5e:58:ac:58:c0:97:fe:65:57:46:
+                    bf:01:cc:d4:d7:64:d8:21:15:02:6b:6a:38:24:bb:
+                    2b:45:c7:79:23:7a:7f:0c:6b:25:d3:ce:e1:3f:e8:
+                    68:6c:31:7a:df:88:49:6d:a3:7e:22:24:08:3d:e1:
+                    6c:87:dd:34:77:d2:a5:eb:f7:e6:74:b9:e2:5f:e4:
+                    ad:49:e1:c0:b4:8f:d9:b5:ac:2d:7b:ba:22:64:8e:
+                    b7:c1:11:11:f1:e1:1f:b9:3e:29:b1:61:9b:8a:1c:
+                    2e:d4:e4:e6:10:5a:5d:e1:f9:1e:54:7b:13:79:dd:
+                    d9:ad:8b:23:c4:8d:a5:8b:f5:17:eb:99:96:5d:c6:
+                    8d:b4:af:8b:4c:2f:08:4d:37:c3:bf:6d:68:99:c4:
+                    f7:47:cc:5d:44:e7:6e:f2:64:b3:7d:bb:9b:c7:e1:
+                    27:cf:73:8d:b2:e2:88:19:6c:bb:6e:cd:4a:0a:79:
+                    a8:7b:9d:c3:b0:59:93:51:20:a1:d8:a2:0f:e5:62:
+                    76:17:b3:bb:aa:bc:3a:73:e7:f6:57:91:6a:cb:d3:
+                    7e:91:38:5e:88:57:e3:d8:3e:31:cd:dc:69:9a:74:
+                    bb:6e:62:c2:ab:5b:8c:f5:80:ff:b4:98:a2:87:15:
+                    72:38:77:76:dc:e2:d1:ac:2f:66:67:ae:c4:33:a8:
+                    86:94:af:41:b1:99:0d:5d:68:df:9a:ec:86:0f:0a:
+                    c9:67:fa:a1:7c:29:47:d3:f1:c1:3d:8a:d1:a4:12:
+                    a6:70:16:37:80:4f:d9:79:61:45:1c:07:77:68:60:
+                    4e:10:ec:94:dd:03:95:b1:37:cc:88:3d:60:cc:32:
+                    37:be:a5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                4A:91:C2:3E:A1:E9:04:C9:C0:9A:8B:CE:D4:37:4D:96:0E:74:FE:90
+            X509v3 Authority Key Identifier:
+                keyid:98:1B:B0:ED:BB:DA:61:98:B5:3A:7A:C8:C4:4E:32:70:A5:F8:A9:07
+                DirName:/CN=ChangeMe
+                serial:11:14:BB:FF:67:35:08:C1:E0:18:DF:ED:DB:C4:72:F0:0E:6D:45:2C
+
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication
+            X509v3 Key Usage:
+                Digital Signature, Key Encipherment
+            X509v3 Subject Alternative Name:
+                DNS:server
+    Signature Algorithm: sha256WithRSAEncryption
+         72:b4:75:02:f7:7b:e9:07:c6:79:1b:bb:11:e4:73:4a:b4:76:
+         1c:03:b9:58:8c:0a:80:f0:c6:8c:cc:2a:a7:c7:8c:57:a8:6e:
+         52:19:f0:b5:7c:0f:06:ab:2f:04:0e:99:32:b9:2c:b6:42:f0:
+         f5:5b:97:32:ce:bb:0c:ee:9f:b0:0b:bc:0b:c0:43:1d:7d:04:
+         b4:a1:cf:a0:aa:fe:f1:cc:b4:31:b3:bb:78:ed:0e:60:8d:37:
+         ea:48:a7:b4:2d:6d:64:6e:97:15:aa:e4:9b:b4:68:79:c8:3b:
+         ba:91:0b:db:cd:04:a3:aa:e4:69:59:06:ec:50:68:6d:0d:a6:
+         38:32:55:76:09:10:00:da:ac:a8:9e:ad:ad:95:8f:01:88:c9:
+         40:af:9a:5c:2d:17:34:81:6b:26:65:8a:e5:2a:15:79:13:2d:
+         ae:d8:03:16:6b:e9:b6:cd:f3:cb:d5:4d:5f:40:76:7a:99:99:
+         d5:2f:e8:a1:59:88:01:6b:a1:36:c0:53:dc:46:07:fd:ab:ab:
+         2a:5b:d3:d5:4c:84:c2:fb:48:16:80:80:01:f6:37:80:3a:54:
+         81:11:24:86:a6:a2:9a:73:06:5f:ca:24:8c:20:3a:40:6e:95:
+         8e:44:46:ef:60:bc:9d:11:ad:71:af:61:85:a6:e2:b4:49:c7:
+         fa:bb:ef:b5:c9:02:d2:a2:a5:3b:f6:46:03:dc:58:9f:ff:dc:
+         23:6b:b5:02:4c:1a:1a:80:99:6d:1a:fd:24:fc:32:83:f7:de:
+         fd:2b:b2:45:b7:3b:89:3c:49:0c:3d:0b:05:67:a5:95:00:3d:
+         cd:a7:0a:3b:b5:cd:02:10:09:de:ff:6c:6b:8b:aa:9d:e6:e9:
+         07:83:e2:dd:de:6d:bc:9e:fd:19:77:30:5d:67:12:c2:33:40:
+         0f:13:69:98:02:ef:05:b2:ad:ef:fb:73:15:57:70:46:83:32:
+         a9:05:4d:31:06:3d:44:93:88:69:de:9a:67:b4:6b:b7:0d:6b:
+         69:24:8b:62:52:f7:85:66:8f:84:2d:c0:a7:ff:33:37:7c:f3:
+         d1:1f:8c:b6:16:a3:98:db:6e:aa:e5:eb:d8:ed:06:31:19:ba:
+         01:f1:e6:3e:bc:78:ec:6e:b4:af:6c:8a:49:0f:ff:5a:f0:00:
+         88:d8:66:af:d6:49:31:b5:54:ce:be:07:59:46:bb:67:73:4b:
+         b8:ec:be:16:04:ed:fe:75:57:21:d6:d5:7b:cc:d0:7c:bd:91:
+         d3:6e:61:72:04:30:24:45:0a:0d:16:b6:35:94:49:02:14:8d:
+         2d:1d:71:42:13:9a:02:1e:3c:31:05:b4:76:5b:dd:ff:bb:db:
+         f4:31:b7:47:bb:54:f8:27
+-----BEGIN CERTIFICATE-----
+MIIFYjCCA0qgAwIBAgIRAJeAxmu1hIGzK/ZWVdpnTcgwDQYJKoZIhvcNAQELBQAw
+EzERMA8GA1UEAwwIQ2hhbmdlTWUwHhcNMjMwNjMwMTE0NTEyWhcNMjUxMDAyMTE0
+NTEyWjARMQ8wDQYDVQQDDAZzZXJ2ZXIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+ggIKAoICAQC+9+4VvLbhBCg+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzp
+dSdVJDn87pLR2t7iXwFQtq5SGnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV
+0SgttwhOoGT7xrTii2FoTnJyzNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWY
+nkg8BJfNozaSFRKkv0bqlTcMbwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2Lq
+onkBedBYqix/iRS8PobAXlisWMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8M
+ayXTzuE/6GhsMXrfiElto34iJAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17
+uiJkjrfBERHx4R+5PimxYZuKHC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZd
+xo20r4tMLwhNN8O/bWiZxPdHzF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7
+ncOwWZNRIKHYog/lYnYXs7uqvDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKr
+W4z1gP+0mKKHFXI4d3bc4tGsL2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT
+8cE9itGkEqZwFjeAT9l5YUUcB3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABo4Gy
+MIGvMAkGA1UdEwQCMAAwHQYDVR0OBBYEFEqRwj6h6QTJwJqLztQ3TZYOdP6QME4G
+A1UdIwRHMEWAFJgbsO272mGYtTp6yMROMnCl+KkHoRekFTATMREwDwYDVQQDDAhD
+aGFuZ2VNZYIUERS7/2c1CMHgGN/t28Ry8A5tRSwwEwYDVR0lBAwwCgYIKwYBBQUH
+AwEwCwYDVR0PBAQDAgWgMBEGA1UdEQQKMAiCBnNlcnZlcjANBgkqhkiG9w0BAQsF
+AAOCAgEAcrR1Avd76QfGeRu7EeRzSrR2HAO5WIwKgPDGjMwqp8eMV6huUhnwtXwP
+BqsvBA6ZMrkstkLw9VuXMs67DO6fsAu8C8BDHX0EtKHPoKr+8cy0MbO7eO0OYI03
+6kintC1tZG6XFarkm7Roecg7upEL280Eo6rkaVkG7FBobQ2mODJVdgkQANqsqJ6t
+rZWPAYjJQK+aXC0XNIFrJmWK5SoVeRMtrtgDFmvpts3zy9VNX0B2epmZ1S/ooVmI
+AWuhNsBT3EYH/aurKlvT1UyEwvtIFoCAAfY3gDpUgREkhqaimnMGX8okjCA6QG6V
+jkRG72C8nRGtca9hhabitEnH+rvvtckC0qKlO/ZGA9xYn//cI2u1AkwaGoCZbRr9
+JPwyg/fe/SuyRbc7iTxJDD0LBWellQA9zacKO7XNAhAJ3v9sa4uqnebpB4Pi3d5t
+vJ79GXcwXWcSwjNADxNpmALvBbKt7/tzFVdwRoMyqQVNMQY9RJOIad6aZ7Rrtw1r
+aSSLYlL3hWaPhC3Ap/8zN3zz0R+MthajmNtuquXr2O0GMRm6AfHmPrx47G60r2yK
+SQ//WvAAiNhmr9ZJMbVUzr4HWUa7Z3NLuOy+FgTt/nVXIdbVe8zQfL2R025hcgQw
+JEUKDRa2NZRJAhSNLR1xQhOaAh48MQW0dlvd/7vb9DG3R7tU+Cc=
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQC+9+4VvLbhBCg+
+OGph3e76YYWap75EIlK0z3qGDiGuHithZhcfVNzpdSdVJDn87pLR2t7iXwFQtq5S
+GnlrjVYNg/bUGVBIvMvYach51LqCBduqWBJLNBsV0SgttwhOoGT7xrTii2FoTnJy
+zNqi2Mv1al0TtpjTDKMFeiHj+fveib43rM5MLpWYnkg8BJfNozaSFRKkv0bqlTcM
+bwnhUfVOE5/1aGUOJDhiBPj5DAZyyQPtXW9AO2LqonkBedBYqix/iRS8PobAXlis
+WMCX/mVXRr8BzNTXZNghFQJrajgkuytFx3kjen8MayXTzuE/6GhsMXrfiElto34i
+JAg94WyH3TR30qXr9+Z0ueJf5K1J4cC0j9m1rC17uiJkjrfBERHx4R+5PimxYZuK
+HC7U5OYQWl3h+R5UexN53dmtiyPEjaWL9RfrmZZdxo20r4tMLwhNN8O/bWiZxPdH
+zF1E527yZLN9u5vH4SfPc42y4ogZbLtuzUoKeah7ncOwWZNRIKHYog/lYnYXs7uq
+vDpz5/ZXkWrL036ROF6IV+PYPjHN3GmadLtuYsKrW4z1gP+0mKKHFXI4d3bc4tGs
+L2ZnrsQzqIaUr0GxmQ1daN+a7IYPCsln+qF8KUfT8cE9itGkEqZwFjeAT9l5YUUc
+B3doYE4Q7JTdA5WxN8yIPWDMMje+pQIDAQABAoICAAnfT1OYWevwBxSQXg+JJZ2U
+BRAls9RZ4eSvBSqA+ITD0oJKgM+B15nKEKp6IPVOcBChO/x/5NWDXCeqbrR8rgIs
+3EnCtT/NYsxhS5fgw3ONUfnQa8Gvg+bw1R7n42oNKKtLbnZ3tiVqSMhehr78bi7V
+vNIUEnp2oMbbtXzPo5GxlT/TkyalEd698AYKRr6+vUd4B2q06Lmf1SSzaNNZJVFP
++mj5aJ/+h1up3iUh1gOBGM7gkavEZiyzEYZeAcNTqNE/CO9iXBz9w5/FRs+UuzBz
+29P//tDTyciMCX/8EcL0WhxVX5HR91dxApecjlB7d0qAlFWR+hnM5exl6HcqfC3C
++Uhi5IC+gZjD2KCcHDr9e5WqQ6cu8TeMnoyuHInIV9kUL3Bn1ArOU1dmGS78soeE
+GpqGCRc9Imh8jxs1AVyj9wGzpfuRS8OBpfR5MIlcFwSlZO/6dnJSaF2BH1jnKgBG
+Xn9MvjfHTU/EhLTteXrAJlqQr4e/uAK5QCESFNXLvC0r3qord6b9Y0zHR63SpESJ
+WVUIF9L2fIh0Z4CutPegcbEyWLaaAT4njyR4uCI78g77kK+PGi2NM65Mk+wKt975
+m3Qh4/cNv1ews4h+RflayWC9kiiRVzDHJGTy63k5gdplqrW2rb8gK3ZQaT2gQp9u
+gjKIIFGyi+EIDSukHNdRAoIBAQDuGvE9k1lSvoPgSusogMk7PWTiZbn8MwlEFueM
+ZJk9k8dMSkqF1k5BXG9lHcWuFl2invgTiFJIF7ML0GDsFJR+CzCDsanSGdjyKfGM
+HzHAc7UPAJYBXPX1rxTAhGSirKjArcqYUX3ZGGaTo1yZrsbbarInUhWWNKFBdaQ+
++L3oClGt3GZx7hdxapI/3gnkLvG/C5hWWetLONZAxY6jwJJSA/p2Fx93SlWOtrmT
+KRbM/p8m6sHtsXcBnYTueqWYpJ2mnBIB+Svf5acqQ2Xf8kAIw4Vw9u7a15OlIDGF
+ouWhtSkL4s0YfZjlXswOPZDlF3eT2ilf+OIjv5kEcLdDKOojAoIBAQDNUhfys2TH
+b1NFsIH6X1jtWHUEGOYIM/y/75Vw2pGLb40cMxVPtzsNCvz8id/sCuvx6yUWlBlN
+wjpa+7dOA+FgoXwv1iVsQm1zQlrt2VKaEy29C0tRkSwOjNC0bz1409wzYNnh5Bdx
+KJDvSz9zlefAryJGTSgGOothOjnguzoEJ6DxfkxNyWbxceBgN8JljDhc9dcybKdD
+Uxy2GflXhZvZfCtTbYfWoIV+dTYyZt2QE4PEPXrJHGUFE9ncGynbzAn1Cc/zGBeT
+zFNoYOCWNr7ueRNHQYMRZ1N3dYRdZ9th5mdqqa1eY5lP4PyQYZV6lwmyEfitXwNz
+vhS0sO+pNAyXAoIBAB9OiZOoESGRDTPrhdnwfQT+AIrIB1lCuKAsRsut2nw/NwAv
+8HaChA2SAs+Px5MpO6yLLGEdFnyGKTOPdX71AcVE4V8feA24+k50916OJ3N/gzny
+wMZzG5/vIlJh1f2RqCqVb0LxzBNEYxBcdWt7kIf/EmebIl16lA1QU4U4HXgqCy1K
+AmpOfOSbt5kQL8rB5WVSN/h6oDZmxb0EfMnJIzQHc+IdDjUYIAHAwsu3pljTzcdH
+LLJ9GAGtXXIhzC4yzsu+T5vU0FEDGCS1ceqtJoBAfQYqYaOCntYiUoCYt4q4kCoQ
+6xiiQv09pqTksW191WoqUDBfQBSlN5Be5am98nMCggEAIzEb+7R15J0XN82uKZzo
+IB5WSDKAUw2eF8PX6HT+F1kyZY/36ibszyp//EUhhVLF6Dw2qi0OPT66Q9f7LjsK
+CUcEgyqAVZL5MZVBAp2KQ/BfmZRy/3MTixbluteKQMiHaKMEFWzD+9hJJ0rNgGFE
+TMl35XbaEl88fpi9TOCqbAXi1yGfsIGBzIaJP9Su1Dr5ei2FChaHgMmhFTFUhITZ
+FqjqwCz46HexCeDLPk5VUZmWry8eeZQNWJZzc/+P6CWL210oMHGDsQiHj09zjyup
+BDTqcf8vmO8N5l7VJjFj797PAQA+P/xwTbmxcInZVh7HQadE6WpsrAz7fZEKMwVB
+1wKCAQEA3oqXI9bGGoXFjydUiNMZbuHdIDQCa9t7iDb+J+NAiA7GI8W8DlFYrUST
+S/CoBey/WOW9jPT/A8EBnp8RmPtAJH88qklbqh/YCoKyKZrgqT5IGysRLWwDFrGT
+QoOvR1a6SaVMLskmYUCkl8Yz8sZS58X50ahxx5TB0I3xsoCmnMZt+cd2C/VXwhFz
+jCiEZIuQlSgQFW4LOFrxrXmI+MDOBWu4zvkztWOnTe+BNgrxndGVI6sdFGzWeNQx
+dQ9imn0UqGSkgnJEj7Lq67ey8Cuu6yYWexKI0N9UOcyL4FgaEdWiJ0t5KY6NElGI
+0jrZX7pwVf/pvbKW2zVm6nXjWJ/JFw==
+-----END PRIVATE KEY-----
+</key>
+<dh>
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEAqJI9Luwkfy0E95gqZyq031Fa1rUCW5aBoppgm4YHxGUL+fUQzveF
+U2+W5xzmZuxhyoN0PVqlPXoMi0xGyTW4ga8qMaIHDqQ/V8RNxQYJ+GEEiC46/2u9
+Co/HbGX9YXMm5nnNEtHepAHcJiRB6QbCjzVm06x5QfWifj/yTm9ycVfJXhQJiOkD
+j4y4vJbgrmIKWX8Nxj4Q8dCAJzZ2gFvMnW9XcbS9SYbyvS0DvoQG3gPTGcopv7x1
+NiOhrxcTcMjwi/2z6kxG0MJEZ1HOJ2xTtRReUGXkL0lhbVTzkX4V6ihWK4MZYqe+
+ozy/0gbPAB4dT1QNeSRXPOi9f81Oed0SoC83P0oiq3JRQq2g7aS9OiwqlRPnVnvH
+q7Uko6+nv8XLbANgbdLXc8I3K78TSedwofxI/atxKncEic0fHV5ai2IdEWt22qxj
+iWVyaiHlWtMosZvuepSPn3cAmfuj0dVPNiRoG97neN8XIOaVZNGmNnI4yM0JEA1h
+Ef4Lh4YpDdqk4Q/nC/zJev8PM1XC+Os1SsGH50YAn8q19TGzI26/Y4jWfqrHswsj
+6vF/lxDS5RRzLIqlEksm84MU1q0AFSe9FaW1NTtKR/PLO1QiSKr718BwzzrDNN9u
+KZJabQ9n1RgLSuMP9zk9A6GUPQ7cZ0fJchUPeuF8Cd7zAV7k4m0RA4MCAQI=
+-----END DH PARAMETERS-----
+</dh>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+c6a3616134ba696526f84d92101568d7
+9fc2475d84662ff95006c44818228e7e
+bc0d798cc503f7cd0b610b243821b8eb
+2902a2db027fc77034d793250f2012cf
+a73a13988ce33992bd01d45e31192b9b
+901d5276483c1856facb89617c8f2eff
+063c4247898968cb4a3136a96a60a1ca
+f06bf0929452a5ed628a38235dafdc2e
+21183a859a3d49780a195330ee8e093b
+9ace3ee877210e3ff51d0d58a6b09e5f
+37b7877514dc6d487e431aa2d77ed857
+5a6987ddbac3323a4d7177542deed2ba
+f169822453e115c841fb59446263b106
+045204603da94d76bff0baf6ca611679
+5d32b90d5ff1c7682923ff02046799c3
+63431f1365fdd9a1a8e670e81be11c97
+-----END OpenVPN Static key V1-----
+</tls-auth>


### PR DESCRIPTION
Docker image tag conventions are starting to become clear that it is preferred to omit `v` prefix. While having the `v` prefix in the past might have been common, it is becoming less and less common today, with most of docker official images
(https://github.com/docker-library/official-images) omitting the `v` prefix.
